### PR TITLE
chore: bump minimal go version 1.17 -> 1.18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         runs-on: [ macos-12, macos-11, macos-10.15, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04, windows-latest ]
-        go-version: [ 1.19, 1.18, 1.17 ]
+        go-version: [ 1.20, 1.19, 1.18 ]
         cgo_enabled: # test it compiles with and without cgo
           - 0
           - 1
@@ -50,7 +50,7 @@ jobs:
       image: golang:${{ matrix.go-version }}-${{ matrix.distribution }}
     strategy:
       matrix:
-        go-version: [ 1.19, 1.18, 1.17 ]
+        go-version: [ 1.20, 1.19, 1.18 ]
         distribution: [ bullseye, buster, alpine ]
         cgo_enabled: # test it compiles with and without cgo
           - 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         runs-on: [ macos-12, macos-11, macos-10.15, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04, windows-latest ]
-        go-version: [ 1.20, 1.19, 1.18 ]
+        go-version: [ "1.20", "1.19", "1.18" ]
         cgo_enabled: # test it compiles with and without cgo
           - 0
           - 1
@@ -50,7 +50,7 @@ jobs:
       image: golang:${{ matrix.go-version }}-${{ matrix.distribution }}
     strategy:
       matrix:
-        go-version: [ 1.20, 1.19, 1.18 ]
+        go-version: [ "1.20", "1.19", "1.18" ]
         distribution: [ bullseye, buster, alpine ]
         cgo_enabled: # test it compiles with and without cgo
           - 0
@@ -97,3 +97,4 @@ jobs:
         with:
           platforms: arm64
       - run: docker run --platform=linux/arm64 -v $PWD:$PWD -w $PWD -eCGO_ENABLED=${{ matrix.cgo_enabled }} -eDD_APPSEC_WAF_TIMEOUT=$DD_APPSEC_WAF_TIMEOUT golang go test -v ./...
+      

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/go-libddwaf
 
-go 1.17
+go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.1


### PR DESCRIPTION
# Why ?

As described in [this PR](https://github.com/DataDog/dd-trace-go/pull/1709), we are moving to version 1.18 as the minimal go version supported since go 1.20 has been released.

# How ?

Bumping `go.mod` file and roll out 1.17 from the CI version matrix.

# Tests

Tests still passes