### PR TITLE
ci: remove deprecated ubuntu18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
   native:
     strategy:
       matrix:
-        runs-on: [ macos-12, macos-11, macos-10.15, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04, windows-latest ]
+        runs-on: [ macos-12, macos-11, macos-10.15, ubuntu-22.04, ubuntu-20.04, windows-latest ]
         go-version: [ "1.20", "1.19", "1.18" ]
         cgo_enabled: # test it compiles with and without cgo
           - 0


### PR DESCRIPTION
Remove Ubuntu 18 from CI which is now deprecated.