### PR TITLE
Public API: Replace Health() by SupportsTarget()

### DIFF
--- a/waf.go
+++ b/waf.go
@@ -113,7 +113,7 @@ func Load() (ok bool, err error) {
 }
 
 // SupportsTarget returns true and a nil error when the target host environment
-// is not supported, such as with a non-supported operating-system.
+// is supported by this package and can be further used.
 // Otherwise, it returns false along with an error detailing why.
 func SupportsTarget() (bool, error) {
 	return supportsTarget()

--- a/waf.go
+++ b/waf.go
@@ -112,14 +112,11 @@ func Load() (ok bool, err error) {
 	return wafLib != nil, wafErr
 }
 
-// Health returns an error when this package is not in a usable state describing
-// the reason why.
-func Health() error {
-	ok, err := Load()
-	if !ok {
-		return err
-	}
-	return nil
+// SupportsTarget returns true and a nil error when the target host environment
+// is not supported, such as with a non-supported operating-system.
+// Otherwise, it returns false along with an error detailing why.
+func SupportsTarget() (bool, error) {
+	return supportsTarget()
 }
 
 var wafVersion string

--- a/waf_dl.go
+++ b/waf_dl.go
@@ -161,3 +161,8 @@ func (waf *wafDl) wafRun(context wafContext, obj *wafObject, result *wafResult, 
 	keepAlive(timeout)
 	return rc
 }
+
+// Implement SupportsTarget()
+func supportsTarget() (bool, error) {
+	return true, nil
+}

--- a/waf_dl_unsupported.go
+++ b/waf_dl_unsupported.go
@@ -15,8 +15,10 @@ import (
 
 type wafDl struct{}
 
+var UnsupportedTargetErr = &UnsupportedTargetError{fmt.Errorf("the target operating-system %s or architecture %s are not supported", runtime.GOOS, runtime.GOARCH)}
+
 func newWafDl() (dl *wafDl, err error) {
-	return nil, &UnsupportedTargetError{fmt.Errorf("the target operating-system %s or architecture %s are not supported", runtime.GOOS, runtime.GOARCH)}
+	return nil, UnsupportedTargetErr
 }
 
 func (waf *wafDl) wafGetVersion() string {
@@ -49,4 +51,11 @@ func (waf *wafDl) wafResultFree(result *wafResult) {
 
 func (waf *wafDl) wafRun(context wafContext, obj *wafObject, result *wafResult, timeout uint64) wafReturnCode {
 	return wafErrInternal
+}
+
+// Implement SupportsTarget()
+func supportsTarget() (bool, error) {
+	// TODO: provide finer-grained unsupported target error message giving the
+	//    exact reason why
+	return false, UnsupportedTargetErr
 }

--- a/waf_dl_unsupported.go
+++ b/waf_dl_unsupported.go
@@ -15,10 +15,10 @@ import (
 
 type wafDl struct{}
 
-var UnsupportedTargetErr = &UnsupportedTargetError{fmt.Errorf("the target operating-system %s or architecture %s are not supported", runtime.GOOS, runtime.GOARCH)}
+var unsupportedTargetErr = &UnsupportedTargetError{fmt.Errorf("the target operating-system %s or architecture %s are not supported", runtime.GOOS, runtime.GOARCH)}
 
 func newWafDl() (dl *wafDl, err error) {
-	return nil, UnsupportedTargetErr
+	return nil, unsupportedTargetErr
 }
 
 func (waf *wafDl) wafGetVersion() string {
@@ -57,5 +57,5 @@ func (waf *wafDl) wafRun(context wafContext, obj *wafObject, result *wafResult, 
 func supportsTarget() (bool, error) {
 	// TODO: provide finer-grained unsupported target error message giving the
 	//    exact reason why
-	return false, UnsupportedTargetErr
+	return false, unsupportedTargetErr
 }

--- a/waf_test.go
+++ b/waf_test.go
@@ -24,7 +24,7 @@ import (
 
 func init() {
 	if ok, err := Load(); !ok {
-	    panic(err)
+		panic(err)
 	}
 }
 
@@ -35,6 +35,12 @@ func TestLoad(t *testing.T) {
 
 	ok, err = Load()
 	require.True(t, ok)
+	require.NoError(t, err)
+}
+
+func TestSupportsTarget(t *testing.T) {
+	supported, err := SupportsTarget()
+	require.True(t, supported)
 	require.NoError(t, err)
 }
 

--- a/waf_unsupported_test.go
+++ b/waf_unsupported_test.go
@@ -24,6 +24,8 @@ func TestLoad(t *testing.T) {
 	require.Truef(t, errors.As(err, &expectedErr), "unexpected error of type %[1]T: %[1]v", err)
 }
 
-func TestHealth(t *testing.T) {
-	require.Error(t, waf.Health())
+func TestSupportsTarget(t *testing.T) {
+	supported, err := waf.SupportsTarget()
+	require.False(t, supported)
+	require.Error(t, err)
 }


### PR DESCRIPTION
While integrating go-libddwaf v1.3.0 into dd-trace-go, we figured out that `Load()` was doing too much for the case of remote activation of appsec when in a disabled state, where we don't want to load libddwaf at all until appsec actually starts up remote activation order.

For this reason, we decided to make `Health()` useful again by replacing it with `SupportsTarget()` in order to be able to only check if we are on a supported target or not. This allows us to properly check for proper support of libddwaf, apart from the libddwaf loading, to do it early in the appsec startup and be able to properly log the information to the user.