### PR TITLE
api: explicitly disable future go versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,14 +15,11 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04, windows-latest ]
-        go-version: [ "1.21-rc.1", "1.20", "1.19", "1.18" ]
+        go-version: [ "1.20", "1.19", "1.18" ]
         cgo_enabled: [ "0", "1" ] # test it compiles with and without cgo
         include:
           - env:
               GODEBUG=cgocheck=2
-          - env:
-              GOEXPERIMENT=cgocheck2
-            go-version: "1.21-rc.1"
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v3
@@ -55,7 +52,7 @@ jobs:
 
       # Install gcc and the libc headers on alpine images
       - if: ${{ matrix.distribution == 'alpine' }}
-        run: apk add libc6-compat
+        run: apk add gcc libc6-compat
 
       - name: Go modules cache
         uses: actions/cache@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,13 +17,13 @@ jobs:
         runs-on: [ macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04, windows-latest ]
         go-version: [ "1.21-rc.1", "1.20", "1.19", "1.18" ]
         cgo_enabled: [ "0", "1" ] # test it compiles with and without cgo
-        env: []
+        env:
         include:
           - env:
               GODEBUG=cgocheck=2
           - env:
               GOEXPERIMENT=cgocheck2
-            go-version: go1.21-rc.1
+            go-version: "1.21-rc.1"
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,8 +45,13 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [ "1.21-rc", "1.20", "1.19", "1.18" ]
-        distribution: [ bookworm, bullseye, alpine ]
+        distribution: [ bookworm, bullseye, buster, alpine ]
         cgo_enabled: [ "0", "1" ] # test it compiles with and without cgo
+        exclude:
+          - go-version: 1.18
+            distribution: bookworm
+          - go-version: 1.21-rc
+            distribution: buster
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,10 +23,6 @@ jobs:
             go-version: go1.21-rc.1
           - env:
               GODEBUG=cgocheck=2
-        exclude:
-          - go-version: go1.21-rc.1
-            env:
-              GODEBUG=cgocheck=2
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         runs-on: [ macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04, windows-latest ]
-        go-version: [ "1.21-rc.3", "1.20", "1.19", "1.18" ]
+        go-version: [ "1.21rc3", "1.20", "1.19", "1.18" ]
         cgo_enabled: # test it compiles with and without cgo
           - 0
           - 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
 
       # Install gcc and the libc headers on alpine images
       - if: ${{ matrix.distribution == 'alpine' }}
-        run: apk add gcc libc6-compat
+        run: apk add gcc musl-dev libc6-compat
 
       - name: Go modules cache
         uses: actions/cache@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,17 +9,22 @@ on:
       - main
 env:
   DD_APPSEC_WAF_TIMEOUT: 5s
-  GODEBUG: cgocheck=2 # highest level of run-time cgo checks
 jobs:
   native:
     strategy:
+      fail-fast: false
       matrix:
         runs-on: [ macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04, windows-latest ]
-        go-version: [ "go1.21rc3", "1.20", "1.19", "1.18" ]
-        cgo_enabled: # test it compiles with and without cgo
-          - 0
-          - 1
-      fail-fast: false
+        go-version: [ "1.21-rc.1", "1.20", "1.19", "1.18" ]
+        cgo_enabled: [ "0", "1" ] # test it compiles with and without cgo
+        include:
+          - env:
+              GOEXPERIMENT=cgocheck2
+            go-version: go1.21-rc.1
+        exclude:
+          - go-version: go1.21-rc.1
+            env:
+              GODEBUG=cgocheck=2
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v3
@@ -34,7 +39,7 @@ jobs:
           # Install gotestsum
           env GOBIN=$PWD go install gotest.tools/gotestsum@latest
           # Run the tests with gotestsum
-          env CGO_ENABLED=${{ matrix.cgo_enabled }} ./gotestsum -- -v -count=10 -shuffle=on ./...
+          env ${{ matrix.env }} CGO_ENABLED=${{ matrix.cgo_enabled }} ./gotestsum -- -v -count=10 -shuffle=on ./...
 
   # Same tests but on the official golang container for linux
   golang-linux-container:
@@ -45,9 +50,7 @@ jobs:
       matrix:
         go-version: [ "1.21-rc", "1.20", "1.19", "1.18" ]
         distribution: [ bullseye, buster, alpine ]
-        cgo_enabled: # test it compiles with and without cgo
-          - 0
-          - 1
+        cgo_enabled: [ "0", "1" ] # test it compiles with and without cgo
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -73,9 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cgo_enabled: # test it compiles with and without the cgo
-          - 0
-          - 1
+        cgo_enabled: [ "0", "1" ] # test it compiles with and without the cgo
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ jobs:
         runs-on: [ macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04, windows-latest ]
         go-version: [ "1.21-rc.1", "1.20", "1.19", "1.18" ]
         cgo_enabled: [ "0", "1" ] # test it compiles with and without cgo
-        env:
         include:
           - env:
               GODEBUG=cgocheck=2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         runs-on: [ macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04, windows-latest ]
-        go-version: [ "1.21rc3", "1.20", "1.19", "1.18" ]
+        go-version: [ "go1.21rc3", "1.20", "1.19", "1.18" ]
         cgo_enabled: # test it compiles with and without cgo
           - 0
           - 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
           - env:
               GOEXPERIMENT=cgocheck2
             go-version: go1.21-rc.1
+          - env:
+              GODEBUG=cgocheck=2
         exclude:
           - go-version: go1.21-rc.1
             env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,13 @@ jobs:
         runs-on: [ macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04, windows-latest ]
         go-version: [ "1.21-rc.1", "1.20", "1.19", "1.18" ]
         cgo_enabled: [ "0", "1" ] # test it compiles with and without cgo
+        env: []
         include:
+          - env:
+              GODEBUG=cgocheck=2
           - env:
               GOEXPERIMENT=cgocheck2
             go-version: go1.21-rc.1
-          - env:
-              GODEBUG=cgocheck=2
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v3
@@ -45,16 +46,17 @@ jobs:
     container:
       image: golang:${{ matrix.go-version }}-${{ matrix.distribution }}
     strategy:
+      fail-fast: false
       matrix:
         go-version: [ "1.21-rc", "1.20", "1.19", "1.18" ]
-        distribution: [ bullseye, buster, alpine ]
+        distribution: [ bookworm, bullseye, alpine ]
         cgo_enabled: [ "0", "1" ] # test it compiles with and without cgo
-      fail-fast: false
     steps:
       - uses: actions/checkout@v3
+
       # Install gcc and the libc headers on alpine images
       - if: ${{ matrix.distribution == 'alpine' }}
-        run: apk add gcc musl-dev libc6-compat git
+        run: apk add libc6-compat
 
       - name: Go modules cache
         uses: actions/cache@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         runs-on: [ macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04, windows-latest ]
-        go-version: [ "1.20", "1.19", "1.18" ]
+        go-version: [ "1.21-rc.3", "1.20", "1.19", "1.18" ]
         cgo_enabled: # test it compiles with and without cgo
           - 0
           - 1
@@ -23,17 +23,10 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
           cache: true
-
-      - name: Go modules cache
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: go-pkg-mod-${{ hashFiles('**/go.sum') }}
-          restore-keys: go-pkg-mod-
 
       - name: go test
         shell: bash
@@ -50,7 +43,7 @@ jobs:
       image: golang:${{ matrix.go-version }}-${{ matrix.distribution }}
     strategy:
       matrix:
-        go-version: [ "1.20", "1.19", "1.18" ]
+        go-version: [ "1.21-rc", "1.20", "1.19", "1.18" ]
         distribution: [ bullseye, buster, alpine ]
         cgo_enabled: # test it compiles with and without cgo
           - 0

--- a/ctypes_test.go
+++ b/ctypes_test.go
@@ -4,7 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Purego only works on linux/macOS with amd64 and arm64 from now
-//go:build (linux || darwin) && (amd64 || arm64)
+//go:build (linux || darwin) && (amd64 || arm64) && !go1.21
 
 package waf
 

--- a/embed_darwin_amd64.go
+++ b/embed_darwin_amd64.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build darwin && amd64
+//go:build darwin && amd64 && !go1.21
 
 package waf
 

--- a/embed_linux_amd64.go
+++ b/embed_linux_amd64.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux && amd64
+//go:build linux && amd64 && !go1.21
 
 package waf
 

--- a/embed_linux_arm64.go
+++ b/embed_linux_arm64.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux && arm64
+//go:build linux && arm64 && !go1.21
 
 package waf
 

--- a/lib_dl.go
+++ b/lib_dl.go
@@ -4,7 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Purego only works on linux/macOS with amd64 and arm64 from now
-//go:build (linux || darwin) && (amd64 || arm64)
+//go:build (linux || darwin) && (amd64 || arm64) && !go1.21
 
 package waf
 

--- a/symbols_linux_cgo.go
+++ b/symbols_linux_cgo.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build cgo && linux
+//go:build cgo && linux && !go1.21
 
 package waf
 

--- a/symbols_linux_purego.go
+++ b/symbols_linux_purego.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !cgo && linux
+//go:build !cgo && linux && !go1.21
 
 package waf
 

--- a/waf_dl.go
+++ b/waf_dl.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (linux || darwin) && (amd64 || arm64)
+//go:build (linux || darwin) && (amd64 || arm64) && !go1.21
 
 package waf
 

--- a/waf_dl_test.go
+++ b/waf_dl_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (linux || darwin) && (amd64 || arm64)
+//go:build (linux || darwin) && (amd64 || arm64) && !go1.21
 
 package waf
 

--- a/waf_dl_unsupported.go
+++ b/waf_dl_unsupported.go
@@ -4,18 +4,11 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Build when the target OS or architecture are not supported
-//go:build (!linux && !darwin) || (!amd64 && !arm64)
+//go:build (!linux && !darwin) || (!amd64 && !arm64) || go1.21
 
 package waf
 
-import (
-	"fmt"
-	"runtime"
-)
-
 type wafDl struct{}
-
-var unsupportedTargetErr = &UnsupportedTargetError{fmt.Errorf("the target operating-system %s or architecture %s are not supported", runtime.GOOS, runtime.GOARCH)}
 
 func newWafDl() (dl *wafDl, err error) {
 	return nil, unsupportedTargetErr

--- a/waf_test.go
+++ b/waf_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (amd64 || arm64) && (linux || darwin)
+//go:build (amd64 || arm64) && (linux || darwin) && !go1.21
 
 package waf
 

--- a/waf_unsupported_go.go
+++ b/waf_unsupported_go.go
@@ -4,6 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Supported OS/Arch but unsupported Go version
+//           Supported OS        Supported Arch     Bad Go Version
 //go:build (linux || darwin) && (amd64 || arm64) && go1.21
 
 package waf

--- a/waf_unsupported_go.go
+++ b/waf_unsupported_go.go
@@ -3,11 +3,14 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build darwin && arm64 && !go1.21
+// Supported OS/Arch but unsupported Go version
+//go:build (linux || darwin) && (amd64 || arm64) && go1.21
 
 package waf
 
-import _ "embed" // Needed for go:embed
+import (
+	"fmt"
+	"runtime"
+)
 
-//go:embed lib/darwin-arm64/_libddwaf.dylib
-var libddwaf []byte
+var unsupportedTargetErr = &UnsupportedTargetError{fmt.Errorf("the Go version %s is not supported", runtime.Version())}

--- a/waf_unsupported_target.go
+++ b/waf_unsupported_target.go
@@ -4,7 +4,8 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Unsupported target OS or architecture on a supported Go version
-//go:build (!linux && !darwin) || (!amd64 && !arm64 && !go1.21)
+//            Unsupported OS        Unsupported Arch      Good Go Version
+//go:build ((!linux && !darwin) || (!amd64 && !arm64)) && !go1.21
 
 package waf
 

--- a/waf_unsupported_target.go
+++ b/waf_unsupported_target.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Unsupported target OS or architecture on a supported Go version
+//go:build (!linux && !darwin) || (!amd64 && !arm64 && !go1.21)
+
+package waf
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var unsupportedTargetErr = &UnsupportedTargetError{fmt.Errorf("the target operating-system %s or architecture %s are not supported", runtime.GOOS, runtime.GOARCH)}

--- a/waf_unsupported_test.go
+++ b/waf_unsupported_test.go
@@ -4,7 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Build when the target OS or Arch are not supported
-//go:build (!linux && !darwin) || (!amd64 && !arm64)
+//go:build (!linux && !darwin) || (!amd64 && !arm64) || go1.21
 
 package waf_test
 


### PR DESCRIPTION
purego is panic'ing on go1.21's release candidate, which will be released in August.
With this PR, we will start enforcing the set of Go versions we know we support and explicitly disable future Go versions until we tested them ourselves. As a result, Go 1.21 is disabled for now until a fix is figured out.