### PR TITLE
ci: native go1.21 tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ jobs:
         include:
           - env:
               GODEBUG=cgocheck=2
+          - go-version: "1.21.0-rc.3"
+            env:
+              GOEXPERIMENT=cgocheck2
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04, windows-latest ]
-        go-version: [ "1.20", "1.19", "1.18" ]
+        go-version: [ "1.21.0-rc.3", "1.20", "1.19", "1.18" ]
         cgo_enabled: [ "0", "1" ] # test it compiles with and without cgo
         include:
           - env:

--- a/waf_unsupported_go.go
+++ b/waf_unsupported_go.go
@@ -5,7 +5,7 @@
 
 // Supported OS/Arch but unsupported Go version
 //           Supported OS        Supported Arch     Bad Go Version
-//go:build (linux || darwin) && (amd64 || arm64) && go1.21
+//go:build (linux || darwin || windows) && (amd64 || arm64) && go1.21
 
 package waf
 


### PR DESCRIPTION
Include more go1.21rc tests, as I figured out how to get the release candidate in the native jobs that were using `@actions/setup-go`.