### PR TITLE
enable go 1.21

### DIFF
--- a/ctypes_test.go
+++ b/ctypes_test.go
@@ -4,7 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Purego only works on linux/macOS with amd64 and arm64 from now
-//go:build (linux || darwin) && (amd64 || arm64) && !go1.21
+//go:build (linux || darwin) && (amd64 || arm64) && !go1.22
 
 package waf
 

--- a/embed_darwin_amd64.go
+++ b/embed_darwin_amd64.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build darwin && amd64 && !go1.21
+//go:build darwin && amd64 && !go1.22
 
 package waf
 

--- a/embed_darwin_arm64.go
+++ b/embed_darwin_arm64.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build darwin && arm64 && !go1.21
+//go:build darwin && arm64 && !go1.22
 
 package waf
 

--- a/embed_linux_amd64.go
+++ b/embed_linux_amd64.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux && amd64 && !go1.21
+//go:build linux && amd64 && !go1.22
 
 package waf
 

--- a/embed_linux_arm64.go
+++ b/embed_linux_arm64.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux && arm64 && !go1.21
+//go:build linux && arm64 && !go1.22
 
 package waf
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/DataDog/go-libddwaf
 go 1.18
 
 require (
-	github.com/ebitengine/purego v0.4.0-alpha.4.0.20230519103000-ee8dcecc618f
+	github.com/ebitengine/purego v0.5.0-alpha
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.1
 	go.uber.org/atomic v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/ebitengine/purego v0.4.0-alpha.4.0.20230519103000-ee8dcecc618f h1:v8f0ADMg0RBM0+5rb8qCFj/XlPkjo+xkyCLuUpBnj9s=
-github.com/ebitengine/purego v0.4.0-alpha.4.0.20230519103000-ee8dcecc618f/go.mod h1:ah1In8AOtksoNK6yk5z1HTJeUkC1Ez4Wk2idgGslMwQ=
+github.com/ebitengine/purego v0.5.0-alpha h1:pNZNC8WofBTN3Nm196An50C5taL/87BhFR/RzKy2o4k=
+github.com/ebitengine/purego v0.5.0-alpha/go.mod h1:ah1In8AOtksoNK6yk5z1HTJeUkC1Ez4Wk2idgGslMwQ=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/lib_dl.go
+++ b/lib_dl.go
@@ -4,7 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Purego only works on linux/macOS with amd64 and arm64 from now
-//go:build (linux || darwin) && (amd64 || arm64) && !go1.21
+//go:build (linux || darwin) && (amd64 || arm64) && !go1.22
 
 package waf
 

--- a/symbols_linux_cgo.go
+++ b/symbols_linux_cgo.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build cgo && linux && !go1.21
+//go:build cgo && linux && !go1.22
 
 package waf
 

--- a/symbols_linux_purego.go
+++ b/symbols_linux_purego.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !cgo && linux && !go1.21
+//go:build !cgo && linux && !go1.22
 
 package waf
 

--- a/waf_dl.go
+++ b/waf_dl.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (linux || darwin) && (amd64 || arm64) && !go1.21
+//go:build (linux || darwin) && (amd64 || arm64) && !go1.22
 
 package waf
 

--- a/waf_dl_test.go
+++ b/waf_dl_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (linux || darwin) && (amd64 || arm64) && !go1.21
+//go:build (linux || darwin) && (amd64 || arm64) && !go1.22
 
 package waf
 

--- a/waf_dl_unsupported.go
+++ b/waf_dl_unsupported.go
@@ -4,7 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Build when the target OS or architecture are not supported
-//go:build (!linux && !darwin) || (!amd64 && !arm64) || go1.21
+//go:build (!linux && !darwin) || (!amd64 && !arm64) || go1.22
 
 package waf
 

--- a/waf_test.go
+++ b/waf_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (amd64 || arm64) && (linux || darwin) && !go1.21
+//go:build (amd64 || arm64) && (linux || darwin) && !go1.22
 
 package waf
 

--- a/waf_unsupported_go.go
+++ b/waf_unsupported_go.go
@@ -5,7 +5,7 @@
 
 // Supported OS/Arch but unsupported Go version
 //           Supported OS        Supported Arch     Bad Go Version
-//go:build (linux || darwin || windows) && (amd64 || arm64) && go1.21
+//go:build (linux || darwin || windows) && (amd64 || arm64) && go1.22
 
 package waf
 

--- a/waf_unsupported_target.go
+++ b/waf_unsupported_target.go
@@ -5,7 +5,7 @@
 
 // Unsupported target OS or architecture on a supported Go version
 //            Unsupported OS        Unsupported Arch      Good Go Version
-//go:build ((!linux && !darwin) || (!amd64 && !arm64)) && !go1.21
+//go:build ((!linux && !darwin) || (!amd64 && !arm64)) && !go1.22
 
 package waf
 

--- a/waf_unsupported_test.go
+++ b/waf_unsupported_test.go
@@ -4,7 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Build when the target OS or Arch are not supported
-//go:build (!linux && !darwin) || (!amd64 && !arm64) || go1.21
+//go:build (!linux && !darwin) || (!amd64 && !arm64) || go1.22
 
 package waf_test
 


### PR DESCRIPTION
As per ebitengine/purego#139 and ebitengine/purego#145. purego now works on Go 1.21