### PR TITLE
fix: handle.NewHandle() now accepts map instead of any

### DIFF
--- a/handle.go
+++ b/handle.go
@@ -42,7 +42,7 @@ type Handle struct {
 // NewHandle creates and returns a new instance of the WAF with the given security rules and configuration
 // of the sensitive data obfuscator. The returned handle is nil in case of an error.
 // Rules-related metrics, including errors, are accessible with the `RulesetInfo()` method.
-func NewHandle(rules any, keyObfuscatorRegex string, valueObfuscatorRegex string) (*Handle, error) {
+func NewHandle(rules map[string]any, keyObfuscatorRegex string, valueObfuscatorRegex string) (*Handle, error) {
 	// The order of action is the following:
 	// - Open the ddwaf C library
 	// - Encode the security rules as a ddwaf_object

--- a/waf_test.go
+++ b/waf_test.go
@@ -139,7 +139,7 @@ func newArachniTestRule(inputs []ruleInput, actions []string) map[string]any {
 	return parsed
 }
 
-func newDefaultHandle(rule any) (*Handle, error) {
+func newDefaultHandle(rule map[string]any) (*Handle, error) {
 	return NewHandle(rule, "", "")
 }
 
@@ -152,7 +152,7 @@ func TestNewWAF(t *testing.T) {
 	})
 
 	t.Run("invalid-rule", func(t *testing.T) {
-		var parsed any
+		var parsed map[string]any
 
 		require.NoError(t, json.Unmarshal([]byte(malformedRule), &parsed))
 
@@ -610,7 +610,7 @@ func TestMetrics(t *testing.T) {
   ]
 }
 `
-	var parsed any
+	var parsed map[string]any
 
 	require.NoError(t, json.Unmarshal([]byte(rules), &parsed))
 


### PR DESCRIPTION
This is to avoid users mistakenly passing a JSON string instead of the parsed object.