### PR TITLE
Diagnostics: export fields

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -50,9 +50,9 @@ func decodeDiagnostics(obj *wafObject) (*Diagnostics, error) {
 		key := gostringSized(cast[byte](objElem.parameterName), objElem.parameterNameLength)
 		switch key {
 		case "rules":
-			diags.rules, err = decodeDiagnosticsEntry(objElem)
+			diags.Rules, err = decodeDiagnosticsEntry(objElem)
 		case "ruleset_version":
-			diags.version = gostringSized(cast[byte](objElem.value), objElem.nbEntries)
+			diags.Version = gostringSized(cast[byte](objElem.value), objElem.nbEntries)
 		default:
 			// ignore?
 		}
@@ -79,11 +79,11 @@ func decodeDiagnosticsEntry(obj *wafObject) (*DiagnosticEntry, error) {
 		key := gostringSized(cast[byte](objElem.parameterName), objElem.parameterNameLength)
 		switch key {
 		case "loaded":
-			entry.loaded, err = decodeStringArray(objElem)
+			entry.Loaded, err = decodeStringArray(objElem)
 		case "failed":
-			entry.failed, err = decodeStringArray(objElem)
+			entry.Failed, err = decodeStringArray(objElem)
 		case "errors":
-			entry.errors, err = decodeErrors(objElem)
+			entry.Errors, err = decodeErrors(objElem)
 		default:
 			return nil, errUnsupportedValue
 		}

--- a/waf.go
+++ b/waf.go
@@ -25,18 +25,20 @@ func (e *UnsupportedTargetError) Unwrap() error {
 
 // Diagnostics stores the information - provided by the WAF - about WAF rules initialization.
 type Diagnostics struct {
-	version        string
-	rules          *DiagnosticEntry
-	customRules    *DiagnosticEntry
-	exclusions     *DiagnosticEntry
-	rulesOverrides *DiagnosticEntry
-	rulesData      *DiagnosticEntry
+	Version        string
+	Rules          *DiagnosticEntry
+	CustomRules    *DiagnosticEntry
+	Exclusions     *DiagnosticEntry
+	RulesOverrides *DiagnosticEntry
+	RulesData      *DiagnosticEntry
 }
 
+// DiagnosticEntry stores the information - provided by the WAF - about loaded and failed rules
+// for a specific entry in the WAF ruleset
 type DiagnosticEntry struct {
-	loaded []string
-	failed []string
-	errors map[string][]string
+	Loaded []string
+	Failed []string
+	Errors map[string][]string
 }
 
 // Result stores the multiple values returned by a call to ddwaf_run

--- a/waf_test.go
+++ b/waf_test.go
@@ -618,15 +618,15 @@ func TestMetrics(t *testing.T) {
 	require.NoError(t, err)
 	defer waf.Close()
 	t.Run("Diagnostics", func(t *testing.T) {
-		require.NotNil(t, waf.diagnostics.rules)
-		require.Len(t, waf.diagnostics.rules.failed, 3)
+		require.NotNil(t, waf.diagnostics.Rules)
+		require.Len(t, waf.diagnostics.Rules.Failed, 3)
 		for _, id := range []string{"missing-tags-1", "missing-tags-2", "missing-name"} {
-			require.Contains(t, waf.diagnostics.rules.failed, id)
+			require.Contains(t, waf.diagnostics.Rules.Failed, id)
 		}
-		require.Len(t, waf.diagnostics.rules.loaded, 1)
-		require.Contains(t, waf.diagnostics.rules.loaded, "valid-rule")
-		require.Equal(t, waf.diagnostics.version, "1.2.7")
-		require.Len(t, waf.diagnostics.rules.errors, 1)
+		require.Len(t, waf.diagnostics.Rules.Loaded, 1)
+		require.Contains(t, waf.diagnostics.Rules.Loaded, "valid-rule")
+		require.Equal(t, waf.diagnostics.Version, "1.2.7")
+		require.Len(t, waf.diagnostics.Rules.Errors, 1)
 	})
 
 	t.Run("RunDuration", func(t *testing.T) {


### PR DESCRIPTION
We need to be able to read those fields to actually report diagnostics.
We could either implement getters or simply export the fields. The second option seems more convenient and appropriate.