### PR TITLE
chore: add datadog.no_waf build tag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04, windows-latest ]
+        runs-on: [ macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04 ]
         go-version: [ "1.21", "1.20", "1.19" ]
         cgo_enabled: [ "0", "1" ] # test it compiles with and without cgo
         include:
@@ -30,15 +30,37 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
           cache: true
-      - uses: autero1/action-gotestsum@v2.0.0
+      - name: go test
+        shell: bash
+        run: |
+          # Install gotestsum
+          env GOBIN=$PWD go install gotest.tools/gotestsum@latest
+          # Run the tests with gotestsum
+          env ${{ matrix.env }} CGO_ENABLED=${{ matrix.cgo_enabled }} ./gotestsum -- -v -count=10 -shuffle=on ./...
+
+  disabled:
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ windows-latest, ubuntu-latest, macos-13 ]
+        go-args: [ "-tags datadog.no_waf", "-tags go1.22" ]
+        include:
+          - runs-on: windows-latest
+            go-args: ""
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
         with:
-          gotestsum_version: 1.11.0
-      - name: test enabled waf
+          go-version: 'stable' # get latest stable version from https://github.com/actions/go-versions/blob/main/versions-manifest.json
+          cache: true
+      - name: go test
         shell: bash
-        run: env ${{ matrix.env }} CGO_ENABLED=${{ matrix.cgo_enabled }} gotestsum -- -v -count=10 -shuffle=on ./...
-      - name: test disabled waf
-        shell: bash
-        run: env ${{ matrix.env }} CGO_ENABLED=${{ matrix.cgo_enabled }} gotestsum -- -v -tags datadog.no_waf -shuffle=on ./...
+        run: |
+          # Install gotestsum
+          env GOBIN=$PWD go install gotest.tools/gotestsum@latest
+          # Run the tests with gotestsum
+          ./gotestsum -- -v ${{ matrix.go-tags }} -shuffle=on ./...
 
   # Same tests but on the official golang container for linux
   golang-linux-container:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,14 +30,15 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
           cache: true
-
-      - name: go test
+      - uses: autero1/action-gotestsum@v2.0.0
+        with:
+          gotestsum_version: 1.11.0
+      - name: test enabled waf
         shell: bash
-        run: |
-          # Install gotestsum
-          env GOBIN=$PWD go install gotest.tools/gotestsum@latest
-          # Run the tests with gotestsum
-          env ${{ matrix.env }} CGO_ENABLED=${{ matrix.cgo_enabled }} ./gotestsum -- -v -count=10 -shuffle=on ./...
+        run: env ${{ matrix.env }} CGO_ENABLED=${{ matrix.cgo_enabled }} gotestsum -- -v -count=10 -shuffle=on ./...
+      - name: test disabled waf
+        shell: bash
+        run: env ${{ matrix.env }} CGO_ENABLED=${{ matrix.cgo_enabled }} gotestsum -- -v -tags datadog.no_waf -shuffle=on ./...
 
   # Same tests but on the official golang container for linux
   golang-linux-container:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,24 @@ But with the appearance of `ddwaf_object` tree like structure,
 but also with the intention to build CGO-less bindings, this project size has grown to be a fully integrated brick in the DataDog tracer structure.
 Which in turn made it necessary to document the project, to maintain it in an orderly fashion.
 
+## Supported platforms
+
+This library currently support the following platform doublets:
+
+| OS    | Arch    |
+| ----- | ------- |
+| Linux | amd64   |
+| Linux | aarch64 |
+| OSX   | amd64   |
+| OSX   | arm64   |
+
+This means that when the platform is not supported, top-level functions will return a `WafDisabledError` error including the purpose of it.
+
+Note that:
+* Linux support include for glibc and musl variants
+* OSX under 10.9 is not supported
+* A build tag named `datadog.no_waf` can be manually added to force the WAF to be disabled.
+
 ## Design
 
 The WAF bindings have multiple moving parts that are necessary to understand:

--- a/ctypes_test.go
+++ b/ctypes_test.go
@@ -4,7 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Purego only works on linux/macOS with amd64 and arm64 from now
-//go:build (linux || darwin) && (amd64 || arm64) && !go1.22
+//go:build (linux || darwin) && (amd64 || arm64) && !go1.22 && !datadog.no_waf
 
 package waf
 

--- a/encoder_decoder_test.go
+++ b/encoder_decoder_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (amd64 || arm64) && (linux || darwin) && !go1.22
+//go:build (amd64 || arm64) && (linux || darwin) && !go1.22 && !datadog.no_waf
 
 package waf
 

--- a/handle_test.go
+++ b/handle_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNewHandle(t *testing.T) {
-	if supported, err := supportsTarget(); !supported || err != nil {
+	if supported, err := SupportsTarget(); !supported || err != nil {
 		t.Skip("target is not supported by the WAF")
 		return
 	}

--- a/handle_test.go
+++ b/handle_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNewHandle(t *testing.T) {
-	if supported, err := SupportsTarget(); !supported || err != nil {
+	if supported, err := Health(); !supported || err != nil {
 		t.Skip("target is not supported by the WAF")
 		return
 	}

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build ((darwin && (amd64 || arm64)) || (linux && (amd64 || arm64))) && !go1.22
+//go:build ((darwin && (amd64 || arm64)) || (linux && (amd64 || arm64))) && !go1.22 && !datadog.no_waf
 
 package lib
 

--- a/internal/lib/lib_darwin_amd64.go
+++ b/internal/lib/lib_darwin_amd64.go
@@ -3,7 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build darwin && amd64 && !go1.22
+//go:build darwin && amd64 && !go1.22 && !datadog.no_waf
+
 package lib
 
 import _ "embed" // Needed for go:embed

--- a/internal/lib/lib_darwin_arm64.go
+++ b/internal/lib/lib_darwin_arm64.go
@@ -3,7 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build darwin && arm64 && !go1.22
+//go:build darwin && arm64 && !go1.22 && !datadog.no_waf
+
 package lib
 
 import _ "embed" // Needed for go:embed

--- a/internal/lib/lib_linux_amd64.go
+++ b/internal/lib/lib_linux_amd64.go
@@ -3,7 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux && amd64 && !go1.22
+//go:build linux && amd64 && !go1.22 && !datadog.no_waf
+
 package lib
 
 import _ "embed" // Needed for go:embed

--- a/internal/lib/lib_linux_arm64.go
+++ b/internal/lib/lib_linux_arm64.go
@@ -3,7 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux && arm64 && !go1.22
+//go:build linux && arm64 && !go1.22 && !datadog.no_waf
+
 package lib
 
 import _ "embed" // Needed for go:embed

--- a/internal/noopfree/noopfree.s
+++ b/internal/noopfree/noopfree.s
@@ -7,4 +7,3 @@
 
 TEXT _noop_free_v2(SB), NOSPLIT, $0-0
 	RET
-

--- a/safe_test.go
+++ b/safe_test.go
@@ -22,7 +22,6 @@ func TestTryCall(t *testing.T) {
 			// panic called with an error
 			err := tryCall(func() error {
 				panic(myPanicErr)
-				return myErr
 			})
 			require.Error(t, err)
 			var panicErr *PanicError
@@ -35,7 +34,6 @@ func TestTryCall(t *testing.T) {
 			str := "woops"
 			err := tryCall(func() error {
 				panic(str)
-				return myErr
 			})
 			require.Error(t, err)
 			var panicErr *PanicError
@@ -48,7 +46,6 @@ func TestTryCall(t *testing.T) {
 			var i int64 = 42
 			err := tryCall(func() error {
 				panic(i)
-				return myErr
 			})
 			require.Error(t, err)
 			var panicErr *PanicError

--- a/symbols_linux_cgo.go
+++ b/symbols_linux_cgo.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build cgo && linux && !go1.22
+//go:build cgo && linux && !go1.22 && !datadog.no_waf
 
 package waf
 

--- a/symbols_linux_purego.go
+++ b/symbols_linux_purego.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !cgo && linux && !go1.22
+//go:build !cgo && linux && !go1.22 && !datadog.no_waf
 
 package waf
 

--- a/waf.go
+++ b/waf.go
@@ -13,15 +13,15 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
-// UnsupportedTargetError is a wrapper error type helping to handle the error
+// WafDisabledError is a wrapper error type helping to handle the error
 // case of trying to execute this package on an unsupported target environment.
-type UnsupportedTargetError struct {
+type WafDisabledError struct {
 	error
 }
 
 // Unwrap the error and return it.
 // Required by errors.Is and errors.As functions.
-func (e *UnsupportedTargetError) Unwrap() error {
+func (e *WafDisabledError) Unwrap() error {
 	return e.error
 }
 

--- a/waf.go
+++ b/waf.go
@@ -126,9 +126,8 @@ var (
 	// libddwaf's dynamic library handle and entrypoints
 	wafLib *wafDl
 	// libddwaf's dlopen error if any
-	wafErr      error
+	wafLoadErr  error
 	openWafOnce sync.Once
-	doneWafOnce bool
 )
 
 // Load loads libddwaf's dynamic library. The dynamic library is opened only
@@ -149,17 +148,14 @@ func Load() (ok bool, err error) {
 	}
 
 	openWafOnce.Do(func() {
-		defer func() {
-			doneWafOnce = true
-		}()
-		wafLib, wafErr = newWafDl()
-		if wafErr != nil {
+		wafLib, wafLoadErr = newWafDl()
+		if wafLoadErr != nil {
 			return
 		}
 		wafVersion = wafLib.wafGetVersion()
 	})
 
-	return wafLib != nil, wafErr
+	return wafLib != nil, wafLoadErr
 }
 
 var wafVersion string

--- a/waf_disabled_manually.go
+++ b/waf_disabled_manually.go
@@ -10,7 +10,6 @@ package waf
 
 import (
 	"fmt"
-	"runtime"
 )
 
-var disabledWafErr = &WafDisabledError{fmt.Errorf("the target operating-system %s or architecture %s are not supported", runtime.GOOS, runtime.GOARCH)}
+var disabledWafErr = &WafDisabledError{fmt.Errorf("the WAF has been manually disabled using the `datadog.no_waf` go build tag")}

--- a/waf_disabled_manually.go
+++ b/waf_disabled_manually.go
@@ -8,8 +8,6 @@
 
 package waf
 
-import (
-	"fmt"
-)
-
-var disabledWafErr = &WafDisabledError{fmt.Errorf("the WAF has been manually disabled using the `datadog.no_waf` go build tag")}
+func init() {
+	wafManuallyDisabledErr = ManuallyDisabledError{}
+}

--- a/waf_disabled_manually.go
+++ b/waf_disabled_manually.go
@@ -3,9 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Unsupported target OS or architecture on a supported Go version
-//            Unsupported OS        Unsupported Arch   Good Go Version Not manually disabled
-//go:build ((!linux && !darwin) || (!amd64 && !arm64)) && !go1.22 && !datadog.no_waf
+// Manually set datadog.no_waf build tag
+//go:build datadog.no_waf
 
 package waf
 

--- a/waf_dl.go
+++ b/waf_dl.go
@@ -222,8 +222,3 @@ func resolveWafSymbols(handle uintptr) (symbols wafSymbols, err error) {
 
 	return
 }
-
-// Implement SupportsTarget()
-func supportsTarget() (bool, error) {
-	return true, nil
-}

--- a/waf_dl.go
+++ b/waf_dl.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (linux || darwin) && (amd64 || arm64) && !go1.22
+//go:build (linux || darwin) && (amd64 || arm64) && !go1.22 && !datadog.no_waf
 
 package waf
 

--- a/waf_dl_test.go
+++ b/waf_dl_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (linux || darwin) && (amd64 || arm64) && !go1.22
+//go:build (linux || darwin) && (amd64 || arm64) && !go1.22 && !datadog.no_waf
 
 package waf
 

--- a/waf_dl_unsupported.go
+++ b/waf_dl_unsupported.go
@@ -4,14 +4,14 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Build when the target OS or architecture are not supported
-//go:build (!linux && !darwin) || (!amd64 && !arm64) || go1.22
+//go:build (!linux && !darwin) || (!amd64 && !arm64) || go1.22 || datadog.no_waf
 
 package waf
 
 type wafDl struct{}
 
 func newWafDl() (dl *wafDl, err error) {
-	_, err := Health()
+	_, err = Health()
 	return nil, err
 }
 

--- a/waf_dl_unsupported.go
+++ b/waf_dl_unsupported.go
@@ -4,14 +4,14 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Build when the target OS or architecture are not supported
-//go:build (!linux && !darwin) || (!amd64 && !arm64) || go1.22 || datadog.no_waf
+//go:build (!linux && !darwin) || (!amd64 && !arm64) || go1.22
 
 package waf
 
 type wafDl struct{}
 
 func newWafDl() (dl *wafDl, err error) {
-	return nil, disabledWafErr
+	return nil, nil
 }
 
 func (waf *wafDl) wafGetVersion() string {
@@ -48,11 +48,4 @@ func (waf *wafDl) wafObjectFree(obj *wafObject) {
 
 func (waf *wafDl) wafRun(context wafContext, persistentData, ephemeralData *wafObject, result *wafResult, timeout uint64) wafReturnCode {
 	return wafErrInternal
-}
-
-// Implement SupportsTarget()
-func supportsTarget() (bool, error) {
-	// TODO: provide finer-grained unsupported target error message giving the
-	//    exact reason why
-	return false, disabledWafErr
 }

--- a/waf_dl_unsupported.go
+++ b/waf_dl_unsupported.go
@@ -4,14 +4,14 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Build when the target OS or architecture are not supported
-//go:build (!linux && !darwin) || (!amd64 && !arm64) || go1.22
+//go:build (!linux && !darwin) || (!amd64 && !arm64) || go1.22 || datadog.no_waf
 
 package waf
 
 type wafDl struct{}
 
 func newWafDl() (dl *wafDl, err error) {
-	return nil, unsupportedTargetErr
+	return nil, disabledWafErr
 }
 
 func (waf *wafDl) wafGetVersion() string {
@@ -54,5 +54,5 @@ func (waf *wafDl) wafRun(context wafContext, persistentData, ephemeralData *wafO
 func supportsTarget() (bool, error) {
 	// TODO: provide finer-grained unsupported target error message giving the
 	//    exact reason why
-	return false, unsupportedTargetErr
+	return false, disabledWafErr
 }

--- a/waf_dl_unsupported.go
+++ b/waf_dl_unsupported.go
@@ -11,7 +11,8 @@ package waf
 type wafDl struct{}
 
 func newWafDl() (dl *wafDl, err error) {
-	return nil, nil
+	_, err := Health()
+	return nil, err
 }
 
 func (waf *wafDl) wafGetVersion() string {

--- a/waf_manually_disabled_test.go
+++ b/waf_manually_disabled_test.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build datadog.no_waf
+
+package waf_test
+
+import (
+	"testing"
+
+	waf "github.com/DataDog/go-libddwaf/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoad(t *testing.T) {
+	ok, err := waf.Load()
+	require.False(t, ok)
+	require.Error(t, err)
+}
+
+func TestHealth(t *testing.T) {
+	ok, err := waf.Health()
+	require.False(t, ok)
+	require.Error(t, err)
+	require.ErrorIs(t, err, waf.ManuallyDisabledError{})
+}

--- a/waf_support.go
+++ b/waf_support.go
@@ -6,7 +6,10 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
+// Errors used to report data using the Health function
+// Store all the errors related to why go-liddwaf is unavailable for the current target at runtime.
 var wafSupportErrors []error
+// Not nil if the build tag `datadog.no_waf` is set
 var wafManuallyDisabledErr error
 
 // UnsupportedOSArchError is a wrapper error type helping to handle the error

--- a/waf_support.go
+++ b/waf_support.go
@@ -14,28 +14,29 @@ import (
 // Errors used to report data using the Health function
 // Store all the errors related to why go-liddwaf is unavailable for the current target at runtime.
 var wafSupportErrors []error
+
 // Not nil if the build tag `datadog.no_waf` is set
 var wafManuallyDisabledErr error
 
 // UnsupportedOSArchError is a wrapper error type helping to handle the error
 // case of trying to execute this package when the OS or architecture is not supported.
 type UnsupportedOSArchError struct {
-	os   string
-	arch string
+	Os   string
+	Arch string
 }
 
 func (e UnsupportedOSArchError) Error() string {
-	return fmt.Sprintf("unsupported OS/Arch: %s/%s", e.os, e.arch)
+	return fmt.Sprintf("unsupported OS/Arch: %s/%s", e.Os, e.Arch)
 }
 
 // UnsupportedGoVersionError is a wrapper error type helping to handle the error
 // case of trying to execute this package when the Go version is not supported.
 type UnsupportedGoVersionError struct {
-	version string
+	Version string
 }
 
 func (e UnsupportedGoVersionError) Error() string {
-	return fmt.Sprintf("unsupported Go version: %s", e.version)
+	return fmt.Sprintf("unsupported Go version: %s", e.Version)
 }
 
 // ManuallyDisabledError is a wrapper error type helping to handle the error

--- a/waf_support.go
+++ b/waf_support.go
@@ -33,8 +33,7 @@ func (e UnsupportedGoVersionError) Error() string {
 // ManuallyDisabledError is a wrapper error type helping to handle the error
 // case of trying to execute this package when the WAF has been manually disabled with
 // the `datadog.no_waf` go build tag.
-type ManuallyDisabledError struct {
-}
+type ManuallyDisabledError struct{}
 
 func (e ManuallyDisabledError) Error() string {
 	return "the WAF has been manually disabled using the `datadog.no_waf` go build tag"
@@ -55,10 +54,9 @@ func SupportsTarget() (bool, error) {
 // - The Waf library is not in an unsupported OS/Arch
 // - The Waf library is not in an unsupported Go version
 func Health() (bool, error) {
-
 	var err *multierror.Error
-	if wafErr != nil {
-		err = multierror.Append(err, wafErr)
+	if wafLoadErr != nil {
+		err = multierror.Append(err, wafLoadErr)
 	}
 
 	if len(wafSupportErrors) > 0 {
@@ -69,5 +67,5 @@ func Health() (bool, error) {
 		err = multierror.Append(err, wafManuallyDisabledErr)
 	}
 
-	return (!doneWafOnce || wafLib != nil) && len(wafSupportErrors) == 0 && wafManuallyDisabledErr == nil, err.ErrorOrNil()
+	return (wafLib != nil || wafLoadErr == nil) && len(wafSupportErrors) == 0 && wafManuallyDisabledErr == nil, err.ErrorOrNil()
 }

--- a/waf_support.go
+++ b/waf_support.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 package waf
 
 import (
@@ -66,7 +71,7 @@ func Health() (bool, error) {
 		err = multierror.Append(err, wafSupportErrors...)
 	}
 
-	if wafManuallyDisabledErr == nil {
+	if wafManuallyDisabledErr != nil {
 		err = multierror.Append(err, wafManuallyDisabledErr)
 	}
 

--- a/waf_test.go
+++ b/waf_test.go
@@ -45,6 +45,12 @@ func TestSupportsTarget(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestHealth(t *testing.T) {
+	supported, err := Health()
+	require.True(t, supported)
+	require.NoError(t, err)
+}
+
 func TestVersion(t *testing.T) {
 	// Ensures the library version matches the expected version...
 	require.Equal(t, lib.EmbeddedWAFVersion, Version())

--- a/waf_test.go
+++ b/waf_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (amd64 || arm64) && (linux || darwin) && !go1.22
+//go:build (amd64 || arm64) && (linux || darwin) && !go1.22 && !datadog.no_waf
 
 package waf
 

--- a/waf_unsupported_go.go
+++ b/waf_unsupported_go.go
@@ -3,9 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Supported OS/Arch but unsupported Go version
-//               Supported OS              Supported Arch Bad Go Version Not manually disabled
-//go:build (linux || darwin) && (amd64 || arm64) && go1.22 && !datadog.no_waf
+// Unsupported Go version
+//go:build go1.22
 
 package waf
 

--- a/waf_unsupported_go.go
+++ b/waf_unsupported_go.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Unsupported Go version
+// Unsupported Go versions (>=)
 //go:build go1.22
 
 package waf

--- a/waf_unsupported_go.go
+++ b/waf_unsupported_go.go
@@ -4,8 +4,8 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Supported OS/Arch but unsupported Go version
-//           Supported OS        Supported Arch     Bad Go Version
-//go:build (linux || darwin || windows) && (amd64 || arm64) && go1.22
+//               Supported OS              Supported Arch Bad Go Version Not manually disabled
+//go:build (linux || darwin || windows) && (amd64 || arm64) && go1.22 && !datadog.no_waf
 
 package waf
 
@@ -14,4 +14,4 @@ import (
 	"runtime"
 )
 
-var unsupportedTargetErr = &UnsupportedTargetError{fmt.Errorf("the Go version %s is not supported", runtime.Version())}
+var disabledWafErr = &WafDisabledError{fmt.Errorf("the Go version %s is not supported", runtime.Version())}

--- a/waf_unsupported_go.go
+++ b/waf_unsupported_go.go
@@ -5,13 +5,14 @@
 
 // Supported OS/Arch but unsupported Go version
 //               Supported OS              Supported Arch Bad Go Version Not manually disabled
-//go:build (linux || darwin || windows) && (amd64 || arm64) && go1.22 && !datadog.no_waf
+//go:build (linux || darwin) && (amd64 || arm64) && go1.22 && !datadog.no_waf
 
 package waf
 
 import (
-	"fmt"
 	"runtime"
 )
 
-var disabledWafErr = &WafDisabledError{fmt.Errorf("the Go version %s is not supported", runtime.Version())}
+func init() {
+	wafSupportErrors = append(wafSupportErrors, UnsupportedGoVersionError{runtime.Version()})
+}

--- a/waf_unsupported_go_test.go
+++ b/waf_unsupported_go_test.go
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build go1.22
+
+package waf_test
+
+import (
+	waf "github.com/DataDog/go-libddwaf/v2"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestSupportsTarget(t *testing.T) {
+	supported, err := waf.SupportsTarget()
+	require.False(t, supported)
+	require.Error(t, err)
+	require.ErrorIs(t, err, waf.UnsupportedGoVersionError{})
+}
+
+func TestLoad(t *testing.T) {
+	ok, err := waf.Load()
+	require.False(t, ok)
+	require.Error(t, err)
+}
+
+func TestHealth(t *testing.T) {
+	ok, err := waf.Health()
+	require.False(t, ok)
+	require.Error(t, err)
+}

--- a/waf_unsupported_target.go
+++ b/waf_unsupported_target.go
@@ -10,8 +10,9 @@
 package waf
 
 import (
-	"fmt"
 	"runtime"
 )
 
-var disabledWafErr = &WafDisabledError{fmt.Errorf("the target operating-system %s or architecture %s are not supported", runtime.GOOS, runtime.GOARCH)}
+func init() {
+	wafSupportErrors = append(wafSupportErrors, UnsupportedOSArchError{runtime.GOOS, runtime.GOARCH})
+}

--- a/waf_unsupported_target.go
+++ b/waf_unsupported_target.go
@@ -3,9 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Unsupported target OS or architecture on a supported Go version
-//            Unsupported OS        Unsupported Arch   Good Go Version Not manually disabled
-//go:build ((!linux && !darwin) || (!amd64 && !arm64)) && !go1.22 && !datadog.no_waf
+// Unsupported target OS or architecture
+//            Unsupported OS        Unsupported Arch
+//go:build (!linux && !darwin) || (!amd64 && !arm64)
 
 package waf
 

--- a/waf_unsupported_target_test.go
+++ b/waf_unsupported_target_test.go
@@ -3,17 +3,23 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Build when the target OS or Arch are not supported
-//go:build (!linux && !darwin) || (!amd64 && !arm64) || go1.22 || datadog.no_waf
+//go:build (!linux && !darwin) || (!amd64 && !arm64)
 
 package waf_test
 
 import (
-	"testing"
-
 	waf "github.com/DataDog/go-libddwaf/v2"
 	"github.com/stretchr/testify/require"
+	"runtime"
+	"testing"
 )
+
+func TestSupportsTarget(t *testing.T) {
+	supported, err := waf.SupportsTarget()
+	require.False(t, supported)
+	require.Error(t, err)
+	require.ErrorIs(t, err, waf.UnsupportedOSArchError{runtime.GOOS, runtime.GOARCH})
+}
 
 func TestLoad(t *testing.T) {
 	ok, err := waf.Load()
@@ -21,15 +27,8 @@ func TestLoad(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestSupportsTarget(t *testing.T) {
-	supported, err := waf.SupportsTarget()
-	require.False(t, supported)
-	require.Error(t, err)
-}
-
 func TestHealth(t *testing.T) {
 	ok, err := waf.Health()
 	require.False(t, ok)
-	// TODO: finer-grain error checking of all the different error possibilities (unsupported go version, unsupported target, disabled, etc.)
 	require.Error(t, err)
 }

--- a/waf_unsupported_test.go
+++ b/waf_unsupported_test.go
@@ -30,5 +30,6 @@ func TestSupportsTarget(t *testing.T) {
 func TestHealth(t *testing.T) {
 	ok, err := waf.Health()
 	require.False(t, ok)
+	// TODO: finer-grain error checking of all the different error possibilities (unsupported go version, unsupported target, disabled, etc.)
 	require.Error(t, err)
 }

--- a/waf_unsupported_test.go
+++ b/waf_unsupported_test.go
@@ -9,7 +9,6 @@
 package waf_test
 
 import (
-	"errors"
 	"testing"
 
 	waf "github.com/DataDog/go-libddwaf/v2"
@@ -20,12 +19,16 @@ func TestLoad(t *testing.T) {
 	ok, err := waf.Load()
 	require.False(t, ok)
 	require.Error(t, err)
-	var expectedErr *waf.WafDisabledError
-	require.Truef(t, errors.As(err, &expectedErr), "unexpected error of type %[1]T: %[1]v", err)
 }
 
 func TestSupportsTarget(t *testing.T) {
 	supported, err := waf.SupportsTarget()
 	require.False(t, supported)
+	require.Error(t, err)
+}
+
+func TestHealth(t *testing.T) {
+	ok, err := waf.Health()
+	require.False(t, ok)
 	require.Error(t, err)
 }

--- a/waf_unsupported_test.go
+++ b/waf_unsupported_test.go
@@ -4,7 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Build when the target OS or Arch are not supported
-//go:build (!linux && !darwin) || (!amd64 && !arm64) || go1.22
+//go:build (!linux && !darwin) || (!amd64 && !arm64) || go1.22 || datadog.no_waf
 
 package waf_test
 
@@ -20,7 +20,7 @@ func TestLoad(t *testing.T) {
 	ok, err := waf.Load()
 	require.False(t, ok)
 	require.Error(t, err)
-	var expectedErr *waf.UnsupportedTargetError
+	var expectedErr *waf.WafDisabledError
 	require.Truef(t, errors.As(err, &expectedErr), "unexpected error of type %[1]T: %[1]v", err)
 }
 


### PR DESCRIPTION
- [x] Add `datadog.no_waf` build tag in all go:build directives
- [x] Add platform section as an excuse to talk about `datadog.no_waf` build tag
- [x] Add new file to explain the new reason why the waf could be disabled
- [x] Run the CI with the disabled build tag on most cases to extend coverage to the new file
- [x] Rename "Unsupported" with "Disabled" for some identifiers as it makes more sense now 