### PR TITLE
rename _noop_free -> _noop_free_v2

### DIFF
--- a/internal/noopfree/noopfree.go
+++ b/internal/noopfree/noopfree.go
@@ -10,6 +10,6 @@ package noopfree
 
 import "unsafe"
 
-//go:linkname _noop_free _noop_free
-var _noop_free byte
-var NoopFreeFn uintptr = uintptr(unsafe.Pointer(&_noop_free))
+//go:linkname _noop_free_v2 _noop_free_v2
+var _noop_free_v2 byte
+var NoopFreeFn uintptr = uintptr(unsafe.Pointer(&_noop_free_v2))

--- a/internal/noopfree/noopfree.s
+++ b/internal/noopfree/noopfree.s
@@ -5,6 +5,6 @@
 
 #include "textflag.h"
 
-TEXT _noop_free(SB), NOSPLIT, $0-0
+TEXT _noop_free_v2(SB), NOSPLIT, $0-0
 	RET
 


### PR DESCRIPTION
Go ASM symbols are not bound by the major versioning ABI breakage go imposes, therefore we must change the name of the symbol manually for the v1 and the v2 version to coexist in the same binary.

Example error:
```
link: duplicated definition of symbol _noop_free, from github.com/DataDog/go-libddwaf/internal/noopfree and github.com/DataDog/go-libddwaf/v2/internal/noopfree
```