### PR TITLE
fix: adjust mutex handling around ddwaf_context

### DIFF
--- a/context.go
+++ b/context.go
@@ -43,7 +43,7 @@ func NewContext(handle *Handle) *Context {
 
 	cContext := wafLib.wafContextInit(handle.cHandle)
 	if cContext == 0 {
-		handle.Close() // We couldn't get a context, so we no longer have an implicit reference to the Handle in it...
+		handle.release() // We couldn't get a context, so we no longer have an implicit reference to the Handle in it...
 		return nil
 	}
 

--- a/context.go
+++ b/context.go
@@ -16,22 +16,18 @@ import (
 // when calling it multiple times to run its rules every time new addresses
 // become available. Each request must have its own Context.
 type Context struct {
-	// Instance of the WAF
-	handle   *Handle
-	cContext wafContext
-	// cgoRefs is used to retain go references to WafObjects until the context is destroyed.
-	// As per libddwaf documentation, WAF Objects must be alive during all the context lifetime
-	cgoRefs cgoRefPool
-	// Mutex protecting the use of cContext which is not thread-safe and cgoRefs.
-	mutex sync.Mutex
+	handle *Handle // Instance of the WAF
+
+	cgoRefs  cgoRefPool // Used to retain go data referenced by WAF Objects the context holds
+	cContext wafContext // The C ddwaf_context pointer
 
 	// Stats
-	// Cumulated internal WAF run time - in nanoseconds - for this context.
-	totalRuntimeNs atomic.Uint64
-	// Cumulated overall run time - in nanoseconds - for this context.
-	totalOverallRuntimeNs atomic.Uint64
-	// Cumulated timeout count for this context.
-	timeoutCount atomic.Uint64
+	totalRuntimeNs        atomic.Uint64 // Cumulative internal WAF run time - in nanoseconds - for this context.
+	totalOverallRuntimeNs atomic.Uint64 // Cumulative overall run time - in nanoseconds - for this context.
+	timeoutCount          atomic.Uint64 // Cumulative timeout count for this context.
+
+	// Mutex protecting the use of cContext which is not thread-safe and cgoRefs.
+	mutex sync.Mutex
 }
 
 // NewContext returns a new WAF context of to the given WAF handle.

--- a/encoder.go
+++ b/encoder.go
@@ -20,10 +20,10 @@ import (
 // reference now or in the future, are stored and referenced in the `cgoRefs` field. The user MUST leverage
 // `keepAlive()` with it according to its ddwaf use-case.
 type encoder struct {
+	cgoRefs          cgoRefPool
 	containerMaxSize int
 	stringMaxSize    int
 	objectMaxDepth   int
-	cgoRefs          cgoRefPool
 }
 
 type native interface {

--- a/handle.go
+++ b/handle.go
@@ -145,6 +145,8 @@ func (handle *Handle) Close() {
 	}
 
 	wafLib.wafDestroy(handle.cHandle)
+	handle.diagnostics = Diagnostics{} // Data in diagnostics may no longer be valid (e.g: strings from libddwaf)
+	handle.cHandle = 0                 // Makes it easy to spot use-after-free/double-free issues
 }
 
 // retain increments the reference counter of this Handle. Returns true if the

--- a/handle.go
+++ b/handle.go
@@ -162,12 +162,14 @@ func (handle *Handle) retain() bool {
 func (handle *Handle) addRefCounter(x int32) int32 {
 	for {
 		current := handle.refCounter.Load()
-		if current == 0 {
+		if current <= 0 {
 			// The object was released
 			return 0
 		}
-		if swapped := handle.refCounter.CompareAndSwap(current, current+x); swapped {
-			return current + x
+
+		next := current + x
+		if swapped := handle.refCounter.CompareAndSwap(current, next); swapped {
+			return next
 		}
 	}
 }

--- a/handle.go
+++ b/handle.go
@@ -151,9 +151,17 @@ func (handle *Handle) Close() {
 
 // retain increments the reference counter of this Handle. Returns true if the
 // Handle is still valid, false if it is no longer usable. Calls to retain()
-// must be balanced with calls to Close() in order to avoid leaking Handles.
+// must be balanced with calls to release() in order to avoid leaking Handles.
 func (handle *Handle) retain() bool {
 	return handle.addRefCounter(1) > 0
+}
+
+// retain decrements the reference counter of this Handle, possibly causing it
+// to be completely closed (if no other reference exist to it). The Handle
+// should not be used after release() has been called (unless retain has been
+// called again before then).
+func (handle *Handle) release() {
+	handle.Close()
 }
 
 // addRefCounter adds x to Handle.refCounter. The return valid indicates whether the refCounter reached 0 as part of

--- a/safe.go
+++ b/safe.go
@@ -19,10 +19,10 @@ import (
 // error is unreliable and the caller must rather stop using the library.
 // Examples include safety checks errors.
 type PanicError struct {
-	// The function symbol name that was given to `tryCall()`.
-	in string
 	// The recovered panic error while executing the function `in`.
 	Err error
+	// The function symbol name that was given to `tryCall()`.
+	in string
 }
 
 func newPanicError(in func() error, err error) *PanicError {

--- a/waf.go
+++ b/waf.go
@@ -15,7 +15,6 @@ import (
 
 // Diagnostics stores the information - provided by the WAF - about WAF rules initialization.
 type Diagnostics struct {
-	Version        string
 	Rules          *DiagnosticEntry
 	CustomRules    *DiagnosticEntry
 	Exclusions     *DiagnosticEntry
@@ -23,6 +22,7 @@ type Diagnostics struct {
 	RulesData      *DiagnosticEntry
 	Processors     *DiagnosticEntry
 	Scanners       *DiagnosticEntry
+	Version        string
 }
 
 // TopLevelErrors returns the list of top-level errors reported by the WAF on any of the Diagnostics
@@ -56,10 +56,10 @@ func (d *Diagnostics) TopLevelError() error {
 // for a specific entry in the WAF ruleset
 type DiagnosticEntry struct {
 	Addresses *DiagnosticAddresses
+	Errors    map[string][]string // Item-level errors (map of error message to entity identifiers or index:#)
+	Error     string              // If the entire entry was in error (e.g: invalid format)
 	Loaded    []string            // Successfully loaded entity identifiers (or index:#)
 	Failed    []string            // Failed entity identifiers (or index:#)
-	Error     string              // If the entire entry was in error (e.g: invalid format)
-	Errors    map[string][]string // Item-level errors (map of error message to entity identifiers or index:#)
 }
 
 // DiagnosticAddresses stores the information - provided by the WAF - about the known addresses and

--- a/waf_test.go
+++ b/waf_test.go
@@ -825,9 +825,6 @@ func TestConcurrency(t *testing.T) {
 		wafCtx := NewContext(waf)
 		require.NotNil(t, wafCtx)
 
-		waf.Close()
-		require.Greater(t, waf.refCounter.Load(), int32(0))
-
 		var startBarrier, stopBarrier sync.WaitGroup
 		startBarrier.Add(1)
 		stopBarrier.Add(nbUsers + 1)
@@ -852,6 +849,14 @@ func TestConcurrency(t *testing.T) {
 				}
 			}()
 		}
+
+		go func() {
+			startBarrier.Wait()
+			defer stopBarrier.Done()
+
+			time.Sleep(time.Microsecond)
+			waf.Close()
+		}()
 
 		startBarrier.Done()
 		stopBarrier.Wait()

--- a/waf_test.go
+++ b/waf_test.go
@@ -819,6 +819,10 @@ func TestConcurrency(t *testing.T) {
 	})
 
 	t.Run("concurrent-context-use-destroy", func(t *testing.T) {
+		// This test validates that the WAF Context can be used from multiple
+		// threads, with mixed calls to `ddwaf_run` and `ddwaf_context_destroy`,
+		// which are not thread-safe.
+
 		waf, err := newDefaultHandle(testArachniRule)
 		require.NoError(t, err)
 
@@ -841,7 +845,13 @@ func TestConcurrency(t *testing.T) {
 				startBarrier.Wait()
 				defer stopBarrier.Done()
 
+				// A microsecond sleep gives us some scheduler-backed order of execution randomization
 				time.Sleep(time.Microsecond)
+
+				// Half of these goroutines will try to use wafCtx.Run(...), while the other half will try
+				// to use wafCtx.Close(). The expected outcome is that exactly one call to wafCtx.Close()
+				// effectively releases the WAF context, and between 0 and N calls to wafCtx.Run(...) are
+				// done (those that land after `wafCtx.Close()` happened will be silent no-ops).
 				if n%2 == 0 {
 					wafCtx.Run(RunAddressData{Ephemeral: data}, time.Second)
 				} else {
@@ -854,13 +864,18 @@ func TestConcurrency(t *testing.T) {
 			startBarrier.Wait()
 			defer stopBarrier.Done()
 
+			// A microsecond sleep gives us some scheduler-backed order of execution randomization
 			time.Sleep(time.Microsecond)
+
+			// We also asynchronously release the WAF handle, which is fine to do as the WAF context is
+			// still in use, as the WAF handle has a reference counter guarding it's destruction.
 			waf.Close()
 		}()
 
 		startBarrier.Done()
 		stopBarrier.Wait()
 
+		// Verify the WAF Handle was properly released.
 		require.Zero(t, waf.refCounter.Load())
 	})
 }


### PR DESCRIPTION
- Removes a leftover mutex on `Handle` that no longer served any purpose
- Acquiring the mutex on `Context` prior to calling `ddwaf_context_destroy` to avoid concurrent calls to `ddwaf_run`, as these are not thread-safe.

APPSEC-12585