### PR TITLE
Improve test matrix comprehensiveness

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,10 +100,10 @@ jobs:
           # Prune inexistant build images (debian buster is on LTS but won't get new go version images)
           - go-version: '1.21'
             image: golang:{0}-buster
-          # The amazonlinux:2 variant is only relevant for the default go version yum ships
+          # The amazonlinux:2 variant is only relevant for the default go version yum ships (currently 1.20)
           - go-version: '1.19'
             image: amazonlinux:2
-          - go-version: '1.20'
+          - go-version: '1.21'
             image: amazonlinux:2
     name: linux/${{ matrix.arch }} ${{ format(matrix.image, matrix.go-version) }} cgo=${{ matrix.cgo-enabled }} tags=${{ matrix.go-tags }}
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,7 +111,7 @@ jobs:
         run: |-
           docker run --name gha-${{ github.run_id }} --rm -di                   \
             --platform="linux/${{ matrix.arch }}"                               \
-            -v "${HOME}/go/pkg/mod:/root/go/pkg/mod"                            \
+            -v "${HOME}/go/pkg/mod:/go/pkg/mod"                                 \
             -v "$PWD:$PWD"                                                      \
             -w "$PWD"                                                           \
             -eCGO_ENABLED="${{ matrix.cgo-enabled }}"                           \
@@ -121,14 +121,18 @@ jobs:
             -eLD_DEBUG=all                                                      \
             "golang:${{ matrix.go-version }}-${{ matrix.base }}"
       - name: Install alpine requirements
-        if: matrix.base == 'alpine'
+        if: matrix.base == 'alpine' && matrix.cgo-enabled == '1'
         run: |-
           docker exec -i gha-${{ github.run_id }}                               \
             apk add gcc musl-dev libc6-compat
+      - name: Install gotestsum
+        run: |-
+          docker exec -i gha-${{ github.run_id }}                               \
+            go install gotest.tools/gotestsum@latest
       - name: go test
         run: |-
           docker exec -i gha-${{ github.run_id }}                               \
-            go test -v -count=10 -shuffle=on -tags='${{ matrix.go-tags }}' ./...
+            gotestsum -- -v -count=10 -shuffle=on -tags='${{ matrix.go-tags }}' ./...
       - name: Stop container
         if: always() && steps.container.outcome == 'success'
         run: |-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,7 +118,6 @@ jobs:
             -eDD_APPSEC_WAF_TIMEOUT="${DD_APPSEC_WAF_TIMEOUT}"                  \
             -eGODEBUG="${{ matrix.go-debug }}"                                  \
             -eGOEXPERIMENT="${{ matrix.go-experiment }}"                        \
-            -eLD_DEBUG=all                                                      \
             "golang:${{ matrix.go-version }}-${{ matrix.base }}"
       - name: Install alpine requirements
         if: matrix.base == 'alpine' && matrix.cgo-enabled == '1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,22 +22,22 @@ jobs:
           - 'go1.22'                # Too recent go version (purego compatibility uncertain)
           - 'datadog.no_waf,go1.22' # Explicitly disabled & too recent go version (purego compatibility uncertain)
         include:
-          # gocheck2 is configrued differently in go1.21 than in previous versions
-          - go-version: 1.21
+          # gocheck2 is configured differently in go1.21 than in previous versions
+          - go-version: '1.21'
             go-experiment: cgocheck2
-          - go-version: 1.20
+          - go-version: '1.20'
             go-debug: cgocheck=2
-          - go-version: 1.19
+          - go-version: '1.19'
             go-debug: cgocheck=2
         exclude:
           # Prune redundant checks (the go-next test needs only run once per platform)
-          - go-version: 1.20
+          - go-version: '1.20'
             go-tags: go1.22
-          - go-version: 1.20
+          - go-version: '1.20'
             go-tags: datadog.no_waf,go1.22
-          - go-version: 1.19
+          - go-version: '1.19'
             go-tags: go1.22
-          - go-version: 1.19
+          - go-version: '1.19'
             go-tags: datadog.no_waf,go1.22
     name: ${{ matrix.runs-on }} go${{ matrix.go-version }} cgo=${{ matrix.cgo-enabled }} tags=${{ matrix.go-tags }}
     runs-on: ${{ matrix.runs-on }}
@@ -63,7 +63,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        base: [ alpine, bookworm, bullseye, buster ]
+        image:
+          # Standard golang image
+          - golang:{0}-alpine
+          - golang:{0}-bookworm
+          - golang:{0}-bullseye
+          - golang:{0}-buster
+          # RPM-based image
+          - amazonlinux:2 # pretty popular on AWS workloads
         arch: [ amd64, arm64 ]
         go-version: [ "1.21", "1.20", "1.19" ]
         cgo-enabled: [ "0", "1" ] # test it compiles with and without cgo
@@ -74,26 +81,31 @@ jobs:
           - 'datadog.no_waf,go1.22' # Explicitly disabled & too recent go version (purego compatibility uncertain)
         include:
           # gocheck2 is configured differently in go1.21 than in previous versions
-          - go-version: 1.21
+          - go-version: '1.21'
             go-experiment: cgocheck2
-          - go-version: 1.20
+          - go-version: '1.20'
             go-debug: cgocheck=2
-          - go-version: 1.19
+          - go-version: '1.19'
             go-debug: cgocheck=2
         exclude:
           # Prune redundant checks (the go-next test needs only run once per platform)
-          - go-version: 1.20
+          - go-version: '1.20'
             go-tags: go1.22
-          - go-version: 1.20
+          - go-version: '1.20'
             go-tags: datadog.no_waf,go1.22
-          - go-version: 1.19
+          - go-version: '1.19'
             go-tags: go1.22
-          - go-version: 1.19
+          - go-version: '1.19'
             go-tags: datadog.no_waf,go1.22
           # Prune inexistant build images (debian buster is on LTS but won't get new go version images)
-          - go-version: 1.21
-            base: buster
-    name: linux/${{ matrix.arch }} golang:${{ matrix.go-version }}-${{ matrix.base }} cgo=${{ matrix.cgo-enabled }} tags=${{ matrix.go-tags }}
+          - go-version: '1.21'
+            image: golang:{0}-buster
+          # The amazonlinux:2 variant is only relevant for the default go version yum ships
+          - go-version: '1.19'
+            image: amazonlinux:2
+          - go-version: '1.20'
+            image: amazonlinux:2
+    name: linux/${{ matrix.arch }} ${{ format(matrix.image, matrix.go-version) }} cgo=${{ matrix.cgo-enabled }} tags=${{ matrix.go-tags }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -118,12 +130,17 @@ jobs:
             -eDD_APPSEC_WAF_TIMEOUT="${DD_APPSEC_WAF_TIMEOUT}"                  \
             -eGODEBUG="${{ matrix.go-debug }}"                                  \
             -eGOEXPERIMENT="${{ matrix.go-experiment }}"                        \
-            "golang:${{ matrix.go-version }}-${{ matrix.base }}"
+            "${{ format(matrix.image, matrix.go-version) }}"
       - name: Install alpine requirements
-        if: matrix.base == 'alpine' && matrix.cgo-enabled == '1'
+        if: endsWith(matrix.image, '-alpine') && matrix.cgo-enabled == '1'
         run: |-
           docker exec -i gha-${{ github.run_id }}                               \
             apk add gcc musl-dev libc6-compat
+      - name: Install AmazonLinux 2 requirements
+        if: matrix.image == 'amazonlinux:2'
+        run: |-
+          docker exec -i gha-${{ github.run_id }}                               \
+            yum install -y golang
       - name: Install gotestsum
         run: |-
           docker exec -i gha-${{ github.run_id }}                               \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
           - 'go1.22'                # Too recent go version (purego compatibility uncertain)
           - 'datadog.no_waf,go1.22' # Explicitly disabled & too recent go version (purego compatibility uncertain)
         include:
-          # gocheck2 is configrued differently in go1.21 than in previous versions
+          # gocheck2 is configured differently in go1.21 than in previous versions
           - go-version: 1.21
             go-experiment: cgocheck2
           - go-version: 1.20

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,6 +130,7 @@ jobs:
             -eDD_APPSEC_WAF_TIMEOUT="${DD_APPSEC_WAF_TIMEOUT}"                  \
             -eGODEBUG="${{ matrix.go-debug }}"                                  \
             -eGOEXPERIMENT="${{ matrix.go-experiment }}"                        \
+            -eGOMODCACHE="/go/pkg/mod"                                          \
             "${{ format(matrix.image, matrix.go-version) }}"
       - name: Install alpine requirements
         if: endsWith(matrix.image, '-alpine') && matrix.cgo-enabled == '1'
@@ -148,7 +149,9 @@ jobs:
       - name: go test
         run: |-
           docker exec -i gha-${{ github.run_id }}                               \
-            gotestsum -- -v -count=10 -shuffle=on -tags='${{ matrix.go-tags }}' ./...
+            go run gotest.tools/gotestsum@latest --                             \
+              -v -count=10 -shuffle=on -tags='${{ matrix.go-tags }}'             \
+              ./...
       - name: Stop container
         if: always() && steps.container.outcome == 'success'
         run: |-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,6 +118,7 @@ jobs:
             -eDD_APPSEC_WAF_TIMEOUT="${DD_APPSEC_WAF_TIMEOUT}"                  \
             -eGODEBUG="${{ matrix.go-debug }}"                                  \
             -eGOEXPERIMENT="${{ matrix.go-experiment }}"                        \
+            -eLD_DEBUG=all                                                      \
             "golang:${{ matrix.go-version }}-${{ matrix.base }}"
       - name: Install alpine requirements
         if: matrix.base == 'alpine'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,22 +7,39 @@ on:
   push: # on push to the main branch
     branches:
       - main
-env:
-  DD_APPSEC_WAF_TIMEOUT: 5s
+
 jobs:
-  native:
+  bare-metal:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04 ]
+        runs-on: [ macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04, windows-latest ]
         go-version: [ "1.21", "1.20", "1.19" ]
-        cgo_enabled: [ "0", "1" ] # test it compiles with and without cgo
+        cgo-enabled: [ "0", "1" ] # test it compiles with and without cgo
+        go-tags:
+          - ''                      # Default behavior
+          - 'datadog.no_waf'        # Explicitly disabled WAF
+          - 'go1.22'                # Too recent go version (purego compatibility uncertain)
+          - 'datadog.no_waf,go1.22' # Explicitly disabled & too recent go version (purego compatibility uncertain)
         include:
-          - env:
-              GODEBUG=cgocheck=2
-          - go-version: "1.21"
-            env:
-              GOEXPERIMENT=cgocheck2
+          # gocheck2 is configrued differently in go1.21 than in previous versions
+          - go-version: 1.21
+            go-experiment: cgocheck2
+          - go-version: 1.20
+            go-debug: cgocheck=2
+          - go-version: 1.19
+            go-debug: cgocheck=2
+        exclude:
+          # Prune redundant checks (the go-next test needs only run once per platform)
+          - go-version: 1.20
+            go-tags: go1.22
+          - go-version: 1.20
+            go-tags: datadog.no_waf,go1.22
+          - go-version: 1.19
+            go-tags: go1.22
+          - go-version: 1.19
+            go-tags: datadog.no_waf,go1.22
+    name: ${{ matrix.runs-on }} go${{ matrix.go-version }} cgo=${{ matrix.cgo-enabled }} tags=${{ matrix.go-tags }}
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v3
@@ -30,104 +47,99 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
           cache: true
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
       - name: go test
         shell: bash
-        run: |
-          # Install gotestsum
-          env GOBIN=$PWD go install gotest.tools/gotestsum@latest
-          # Run the tests with gotestsum
-          env ${{ matrix.env }} CGO_ENABLED=${{ matrix.cgo_enabled }} ./gotestsum -- -v -count=10 -shuffle=on ./...
+        run: |-
+          gotestsum -- -v -count=10 -shuffle=on -tags='${{ matrix.go-tags }}' ./...
+        env:
+          CGO_ENABLED: ${{ matrix.cgo-enabled }}
+          DD_APPSEC_WAF_TIMEOUT: 5s
+          GODEBUG: ${{ matrix.go-debug }}
+          GOEXPERIMENT: ${{ matrix.go-experiment }}
 
-  disabled:
+  containerized:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ windows-latest, ubuntu-latest, macos-13 ]
-        go-args: [ "-tags datadog.no_waf", "-tags go1.22" ]
-        include:
-          - runs-on: windows-latest
-            go-args: ""
-    runs-on: ${{ matrix.runs-on }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
-        with:
-          go-version: 'stable' # get latest stable version from https://github.com/actions/go-versions/blob/main/versions-manifest.json
-          cache: true
-      - name: go test
-        shell: bash
-        run: |
-          # Install gotestsum
-          env GOBIN=$PWD go install gotest.tools/gotestsum@latest
-          # Run the tests with gotestsum
-          ./gotestsum -- -v ${{ matrix.go-tags }} -shuffle=on ./...
-
-  # Same tests but on the official golang container for linux
-  golang-linux-container:
-    runs-on: ubuntu-latest
-    container:
-      image: golang:${{ matrix.go-version }}-${{ matrix.distribution }}
-    strategy:
-      fail-fast: false
-      matrix:
+        base: [ alpine, bookworm, bullseye, buster ]
+        arch: [ amd64, arm64 ]
         go-version: [ "1.21", "1.20", "1.19" ]
-        distribution: [ bookworm, bullseye, buster, alpine ]
-        cgo_enabled: [ "0", "1" ] # test it compiles with and without cgo
-        exclude:
-          - go-version: 1.18
-            distribution: bookworm
+        cgo-enabled: [ "0", "1" ] # test it compiles with and without cgo
+        go-tags:
+          - ''                      # Default behavior
+          - 'datadog.no_waf'        # Explicitly disabled WAF
+          - 'go1.22'                # Too recent go version (purego compatibility uncertain)
+          - 'datadog.no_waf,go1.22' # Explicitly disabled & too recent go version (purego compatibility uncertain)
+        include:
+          # gocheck2 is configrued differently in go1.21 than in previous versions
           - go-version: 1.21
-            distribution: buster
+            go-experiment: cgocheck2
+          - go-version: 1.20
+            go-debug: cgocheck=2
+          - go-version: 1.19
+            go-debug: cgocheck=2
+        exclude:
+          # Prune redundant checks (the go-next test needs only run once per platform)
+          - go-version: 1.20
+            go-tags: go1.22
+          - go-version: 1.20
+            go-tags: datadog.no_waf,go1.22
+          - go-version: 1.19
+            go-tags: go1.22
+          - go-version: 1.19
+            go-tags: datadog.no_waf,go1.22
+          # Prune inexistant build images (debian buster is on LTS but won't get new go version images)
+          - go-version: 1.21
+            base: buster
+    name: linux/${{ matrix.arch }} golang:${{ matrix.go-version }}-${{ matrix.base }} cgo=${{ matrix.cgo-enabled }} tags=${{ matrix.go-tags }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      # Install gcc and the libc headers on alpine images
-      - if: ${{ matrix.distribution == 'alpine' }}
-        run: apk add gcc musl-dev libc6-compat
-
-      - name: Go modules cache
-        uses: actions/cache@v3
+      - uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           key: go-pkg-mod-${{ hashFiles('**/go.sum') }}
           restore-keys: go-pkg-mod-
-
-      - name: go test
-        run: |
-          # Install gotestsum
-          env GOBIN=$PWD go install gotest.tools/gotestsum@latest
-          # Run the tests with gotestsum
-          env CGO_ENABLED=${{ matrix.cgo_enabled }} ./gotestsum -- -v -count=10 -shuffle=on ./...
-
-  linux-other:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: ["arm64"]
-        cgo_enabled: [ "0", "1" ] # test it compiles with and without the cgo
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v3
-      - name: Go modules cache
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: go-pkg-mod-${{ matrix.arch }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: go-pkg-mod-${{ matrix.arch }} go-pkg-mod-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
         with:
           platforms: ${{ matrix.arch }}
-      - run: docker run --platform=linux/${{ matrix.arch }} -v${HOME}/go/pkg/mod:/root/go/pkg/mod -v $PWD:$PWD -w $PWD -eCGO_ENABLED=${{ matrix.cgo_enabled }} -eDD_APPSEC_WAF_TIMEOUT=$DD_APPSEC_WAF_TIMEOUT golang go test -v -count=10 -shuffle=on ./...
+      - name: Create container
+        id: container
+        run: |-
+          docker run --name gha-${{ github.run_id }} --rm -di                   \
+            --platform="linux/${{ matrix.arch }}"                               \
+            -v "${HOME}/go/pkg/mod:/root/go/pkg/mod"                            \
+            -v "$PWD:$PWD"                                                      \
+            -w "$PWD"                                                           \
+            -eCGO_ENABLED="${{ matrix.cgo-enabled }}"                           \
+            -eDD_APPSEC_WAF_TIMEOUT="${DD_APPSEC_WAF_TIMEOUT}"                  \
+            -eGODEBUG="${{ matrix.go-debug }}"                                  \
+            -eGOEXPERIMENT="${{ matrix.go-experiment }}"                        \
+            "golang:${{ matrix.go-version }}-${{ matrix.base }}"
+      - name: Install alpine requirements
+        if: matrix.base == 'alpine'
+        run: |-
+          docker exec -i gha-${{ github.run_id }}                               \
+            apk add gcc musl-dev libc6-compat
+      - name: go test
+        run: |-
+          docker exec -i gha-${{ github.run_id }}                               \
+            go test -v -count=10 -shuffle=on -tags='${{ matrix.go-tags }}' ./...
+      - name: Stop container
+        if: always() && steps.container.outcome == 'success'
+        run: |-
+          docker stop gha-${{ github.run_id }}
 
   # A simple join target to simplify setting up branch protection settings in GH.
   done:
     name: Done
     runs-on: ubuntu-latest
     needs:
-      - native
-      - golang-linux-container
-      - linux-other
+      - bare-metal
+      - containerized
     steps:
       - name: Done
         run: echo "Done!"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/go-libddwaf/v2
 
-go 1.18
+go 1.19
 
 require (
 	github.com/ebitengine/purego v0.5.0

--- a/waf_manually_disabled.go
+++ b/waf_manually_disabled.go
@@ -4,7 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Manually set datadog.no_waf build tag
-//go:build datadog.no_waf
+//go:build datadog.no_waf && (linux || darwin) && (amd64 || arm64) && !go1.22
 
 package waf
 

--- a/waf_manually_disabled.go
+++ b/waf_manually_disabled.go
@@ -4,7 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Manually set datadog.no_waf build tag
-//go:build datadog.no_waf && (linux || darwin) && (amd64 || arm64) && !go1.22
+//go:build datadog.no_waf
 
 package waf
 

--- a/waf_manually_disabled_test.go
+++ b/waf_manually_disabled_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build datadog.no_waf && (linux || darwin) && (amd64 || arm64) && !go1.22
+//go:build datadog.no_waf
 
 package waf_test
 
@@ -14,15 +14,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLoad(t *testing.T) {
-	ok, err := waf.Load()
-	require.False(t, ok)
-	require.Error(t, err)
-}
+func TestManuallyDisabled(t *testing.T) {
+	t.Run("TestLoad", func(t *testing.T) {
+		ok, err := waf.Load()
+		require.False(t, ok)
+		require.Error(t, err)
+	})
 
-func TestHealth(t *testing.T) {
-	ok, err := waf.Health()
-	require.False(t, ok)
-	require.Error(t, err)
-	require.ErrorIs(t, err, waf.ManuallyDisabledError{})
+	t.Run("TestHealth", func(t *testing.T) {
+		ok, err := waf.Health()
+		require.False(t, ok)
+		require.Error(t, err)
+		require.ErrorIs(t, err, waf.ManuallyDisabledError{})
+	})
 }

--- a/waf_manually_disabled_test.go
+++ b/waf_manually_disabled_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build datadog.no_waf
+//go:build datadog.no_waf && (linux || darwin) && (amd64 || arm64) && !go1.22
 
 package waf_test
 

--- a/waf_support.go
+++ b/waf_support.go
@@ -7,6 +7,7 @@ package waf
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/hashicorp/go-multierror"
 )
@@ -31,12 +32,10 @@ func (e UnsupportedOSArchError) Error() string {
 
 // UnsupportedGoVersionError is a wrapper error type helping to handle the error
 // case of trying to execute this package when the Go version is not supported.
-type UnsupportedGoVersionError struct {
-	Version string
-}
+type UnsupportedGoVersionError struct{}
 
 func (e UnsupportedGoVersionError) Error() string {
-	return fmt.Sprintf("unsupported Go version: %s", e.Version)
+	return fmt.Sprintf("unsupported Go version: %s", runtime.Version())
 }
 
 // ManuallyDisabledError is a wrapper error type helping to handle the error

--- a/waf_unsupported_go.go
+++ b/waf_unsupported_go.go
@@ -8,10 +8,6 @@
 
 package waf
 
-import (
-	"runtime"
-)
-
 func init() {
-	wafSupportErrors = append(wafSupportErrors, UnsupportedGoVersionError{runtime.Version()})
+	wafSupportErrors = append(wafSupportErrors, UnsupportedGoVersionError{})
 }

--- a/waf_unsupported_go_test.go
+++ b/waf_unsupported_go_test.go
@@ -14,21 +14,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSupportsTarget(t *testing.T) {
-	supported, err := waf.SupportsTarget()
-	require.False(t, supported)
-	require.Error(t, err)
-	require.ErrorIs(t, err, waf.UnsupportedGoVersionError{})
-}
+func TestUnsupportedGoRuntime(t *testing.T) {
+	t.Run("TestSupportsTarget", func(t *testing.T) {
+		supported, err := waf.SupportsTarget()
+		require.False(t, supported)
+		require.Error(t, err)
+		require.ErrorIs(t, err, waf.UnsupportedGoVersionError{})
+	})
 
-func TestLoad(t *testing.T) {
-	ok, err := waf.Load()
-	require.False(t, ok)
-	require.Error(t, err)
-}
+	t.Run("TestLoad", func(t *testing.T) {
+		ok, err := waf.Load()
+		require.False(t, ok)
+		require.Error(t, err)
+	})
 
-func TestHealth(t *testing.T) {
-	ok, err := waf.Health()
-	require.False(t, ok)
-	require.Error(t, err)
+	t.Run("TestHealth", func(t *testing.T) {
+		ok, err := waf.Health()
+		require.False(t, ok)
+		require.Error(t, err)
+	})
 }

--- a/waf_unsupported_go_test.go
+++ b/waf_unsupported_go_test.go
@@ -8,9 +8,10 @@
 package waf_test
 
 import (
+	"testing"
+
 	waf "github.com/DataDog/go-libddwaf/v2"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestSupportsTarget(t *testing.T) {

--- a/waf_unsupported_target.go
+++ b/waf_unsupported_target.go
@@ -5,7 +5,7 @@
 
 // Unsupported target OS or architecture
 //            Unsupported OS        Unsupported Arch
-//go:build ((!linux && !darwin) || (!amd64 && !arm64)) && !go1.22
+//go:build (!linux && !darwin) || (!amd64 && !arm64)
 
 package waf
 

--- a/waf_unsupported_target.go
+++ b/waf_unsupported_target.go
@@ -5,7 +5,7 @@
 
 // Unsupported target OS or architecture
 //            Unsupported OS        Unsupported Arch
-//go:build (!linux && !darwin) || (!amd64 && !arm64)
+//go:build ((!linux && !darwin) || (!amd64 && !arm64)) && !go1.22
 
 package waf
 

--- a/waf_unsupported_target_test.go
+++ b/waf_unsupported_target_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build ((!linux && !darwin) || (!amd64 && !arm64)) && !go1.22
+//go:build (!linux && !darwin) || (!amd64 && !arm64)
 
 package waf_test
 
@@ -15,21 +15,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSupportsTarget(t *testing.T) {
-	supported, err := waf.SupportsTarget()
-	require.False(t, supported)
-	require.Error(t, err)
-	require.ErrorIs(t, err, waf.UnsupportedOSArchError{runtime.GOOS, runtime.GOARCH})
-}
+func TestUnsupportedPlatform(t *testing.T) {
 
-func TestLoad(t *testing.T) {
-	ok, err := waf.Load()
-	require.False(t, ok)
-	require.Error(t, err)
-}
+	t.Run("SupportsTarget", func(t *testing.T) {
+		supported, err := waf.SupportsTarget()
+		require.False(t, supported)
+		require.Error(t, err)
+		require.ErrorIs(t, err, waf.UnsupportedOSArchError{runtime.GOOS, runtime.GOARCH})
+	})
 
-func TestHealth(t *testing.T) {
-	ok, err := waf.Health()
-	require.False(t, ok)
-	require.Error(t, err)
+	t.Run("Load", func(t *testing.T) {
+		ok, err := waf.Load()
+		require.False(t, ok)
+		require.Error(t, err)
+	})
+
+	t.Run("Health", func(t *testing.T) {
+		ok, err := waf.Health()
+		require.False(t, ok)
+		require.Error(t, err)
+	})
 }

--- a/waf_unsupported_target_test.go
+++ b/waf_unsupported_target_test.go
@@ -3,15 +3,16 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (!linux && !darwin) || (!amd64 && !arm64)
+//go:build ((!linux && !darwin) || (!amd64 && !arm64)) && !go1.22
 
 package waf_test
 
 import (
-	waf "github.com/DataDog/go-libddwaf/v2"
-	"github.com/stretchr/testify/require"
 	"runtime"
 	"testing"
+
+	waf "github.com/DataDog/go-libddwaf/v2"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSupportsTarget(t *testing.T) {


### PR DESCRIPTION
Run tests with a comprehensive cartesian product of all configurations:
- Operating systems & architectures[^1]
- CGO_ENABLED or not
- Go runtimes: `1.19`, `1.20`, `1.21`
- Go tags: _none_, `datadog.no_waf`, `go1.22`[^2], `datadog.no_waf,go1.22`

This uncovered compatibility gaps in the matrix, which this PR fixes as well:
- unsupported platform or architecture + `datadog.no_waf`
- unsupported go runtime + unsupported platform

[^1]: Multiple architectures are only tested for linux platforms due to technical limitations
[^2]: `go1.22` is a stand-in for future go releases for which `purego` support needs checking