### PR TITLE
add go1.22-rc docker images to the test matrix

### DIFF
--- a/.github/workflows/_test_containerized.yml
+++ b/.github/workflows/_test_containerized.yml
@@ -16,7 +16,7 @@ jobs:
           # RPM-based image
           - amazonlinux:2 # pretty popular on AWS workloads
         arch: [ amd64, arm64 ]
-        go-version: [ "1.21", "1.20", "1.19" ]
+        go-version: [ "1.22-rc", "1.21", "1.20", "1.19" ]
         cgo-enabled: [ "0", "1" ] # test it compiles with and without cgo
         go-tags:
           - ''                      # Default behavior


### PR DESCRIPTION
Prepare for go 1.22 release