### PR TITLE
feat: WAFObject encoder produces truncation information

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -120,7 +120,7 @@ func isValueNil(value reflect.Value) bool {
 }
 
 const (
-	measureOnlyDepth = 128
+	measureOnlyDepth = wafMaxContainerDepth
 )
 
 func (encoder *encoder) encode(value reflect.Value, obj *wafObject, depth int) (int, error) {

--- a/encoder_decoder_test.go
+++ b/encoder_decoder_test.go
@@ -9,6 +9,7 @@ package waf
 
 import (
 	"reflect"
+	"sort"
 	"testing"
 	"time"
 
@@ -344,7 +345,7 @@ func TestEncoderLimits(t *testing.T) {
 			Name:          "key-map-depth",
 			MaxValueDepth: 1,
 			Input:         map[any]any{new(string): "x"},
-			Output:        map[string]any{},
+			Output:        map[string]any{"": "x"},
 		},
 		{
 			Name:          "map-depth",
@@ -483,7 +484,7 @@ func TestEncoderLimits(t *testing.T) {
 		encoded, err := encoder.Encode(tc.Input)
 
 		t.Run(tc.Name+"/assert", func(t *testing.T) {
-			require.Equal(t, tc.Truncations, encoder.Truncations())
+			require.Equal(t, tc.Truncations, sortValues(encoder.Truncations()))
 
 			if tc.EncodeError != nil {
 				require.Error(t, err, "expected an encoding error when encoding %v", tc.EncodeError)
@@ -530,6 +531,18 @@ func assertEqualType(t *testing.T, expected typeTree, actual *wafObject) {
 	for i := range expected.children {
 		assertEqualType(t, expected.children[i], castWithOffset[wafObject](actual.value, uint64(i)))
 	}
+}
+
+func sortValues[K comparable](m map[K][]int) map[K][]int {
+	if m == nil {
+		return nil
+	}
+
+	for _, ints := range m {
+		sort.Ints(ints)
+	}
+
+	return m
 }
 
 func TestEncoderTypeTree(t *testing.T) {

--- a/waf.go
+++ b/waf.go
@@ -80,11 +80,12 @@ type Result struct {
 
 // Encoder/Decoder errors
 var (
-	errMaxDepthExceeded  = errors.New("max depth exceeded")
-	errUnsupportedValue  = errors.New("unsupported Go value")
-	errInvalidMapKey     = errors.New("invalid WAF object map key")
-	errNilObjectPtr      = errors.New("nil WAF object pointer")
-	errInvalidObjectType = errors.New("invalid type encountered when decoding")
+	errMaxDepthExceeded    = errors.New("max depth exceeded")
+	errUnsupportedValue    = errors.New("unsupported Go value")
+	errInvalidMapKey       = errors.New("invalid WAF object map key")
+	errNilObjectPtr        = errors.New("nil WAF object pointer")
+	errInvalidObjectType   = errors.New("invalid type encountered when decoding")
+	errTooManyIndirections = errors.New("too many indirections")
 )
 
 // RunError the WAF can return when running it.


### PR DESCRIPTION
Instead of "silently" performing truncations unless they are required on the top-level value, the encode now keeps tabs on the truncations it performed, recording the set of un-truncated sizes for each truncation cause.

This information will subsequently be made visible to downstream WAF users so that it is possible to implement telemetry tracking of the real-world impact of encoding limits, and possibly gain insight into how to tune them for maximum efficiency.