### PR TITLE
feat: go1.22 support

### DIFF
--- a/.github/workflows/_test_bare_metal.yml
+++ b/.github/workflows/_test_bare_metal.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04, windows-latest ]
+        runs-on: [ macos-14, macos-13, macos-12, ubuntu-22.04, ubuntu-20.04, windows-latest ]
         go-version: [ "1.22.0-rc.2", "1.21", "1.20" ]
         cgo-enabled: [ "0", "1" ] # test it compiles with and without cgo
         go-tags:

--- a/.github/workflows/_test_bare_metal.yml
+++ b/.github/workflows/_test_bare_metal.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04, windows-latest ]
-        go-version: [ "1.21", "1.20", "1.19" ]
+        go-version: [ "1.22-rc.1", "1.21", "1.20" ]
         cgo-enabled: [ "0", "1" ] # test it compiles with and without cgo
         go-tags:
           - ''                      # Default behavior

--- a/.github/workflows/_test_bare_metal.yml
+++ b/.github/workflows/_test_bare_metal.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04, windows-latest ]
-        go-version: [ "1.22-rc.2", "1.21", "1.20" ]
+        go-version: [ "1.22-rc.1", "1.21", "1.20" ]
         cgo-enabled: [ "0", "1" ] # test it compiles with and without cgo
         go-tags:
           - ''                      # Default behavior
@@ -22,7 +22,7 @@ jobs:
           # gocheck2 is configured differently in go1.21 than in previous versions
           - go-version: '1.21'
             go-experiment: cgocheck2
-          - go-version: '1.22-rc.2'
+          - go-version: '1.22-rc.1'
             go-experiment: cgocheck2
           - go-version: '1.20'
             go-debug: cgocheck=2

--- a/.github/workflows/_test_bare_metal.yml
+++ b/.github/workflows/_test_bare_metal.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04, windows-latest ]
-        go-version: [ "1.22-rc.1", "1.21", "1.20" ]
+        go-version: [ "1.22.0-rc.2", "1.21", "1.20" ]
         cgo-enabled: [ "0", "1" ] # test it compiles with and without cgo
         go-tags:
           - ''                      # Default behavior
@@ -22,7 +22,7 @@ jobs:
           # gocheck2 is configured differently in go1.21 than in previous versions
           - go-version: '1.21'
             go-experiment: cgocheck2
-          - go-version: '1.22-rc.1'
+          - go-version: '1.22.0-rc.2'
             go-experiment: cgocheck2
           - go-version: '1.20'
             go-debug: cgocheck=2

--- a/.github/workflows/_test_bare_metal.yml
+++ b/.github/workflows/_test_bare_metal.yml
@@ -13,18 +13,18 @@ jobs:
         go-tags:
           - ''                      # Default behavior
           - 'datadog.no_waf'        # Explicitly disabled WAF
-          - 'go1.22'                # Too recent go version (purego compatibility uncertain)
+          - 'go1.23'                # Too recent go version (purego compatibility uncertain)
           - 'appsec'                # Legacy build tag to enable appsec when cgo is disabled
           - 'appsec,datadog.no_waf' # An awkward combination that must nevertheless compile
-          - 'datadog.no_waf,go1.22' # Explicitly disabled & too recent go version (purego compatibility uncertain)
-          - 'appsec,go1.22'         # Explicitly enabled w/o cgo & too recent go version (purego compatibility uncertain)
+          - 'datadog.no_waf,go1.23' # Explicitly disabled & too recent go version (purego compatibility uncertain)
+          - 'appsec,go1.23'         # Explicitly enabled w/o cgo & too recent go version (purego compatibility uncertain)
         include:
           # gocheck2 is configured differently in go1.21 than in previous versions
           - go-version: '1.21'
             go-experiment: cgocheck2
+          - go-version: '1.22'
+            go-experiment: cgocheck2
           - go-version: '1.20'
-            go-debug: cgocheck=2
-          - go-version: '1.19'
             go-debug: cgocheck=2
           # Test with DD_APPSEC_WAF_LOG_LEVEL (only latest go, without any particular tag)
           - go-version: '1.21'
@@ -32,19 +32,19 @@ jobs:
             waf-log-level: TRACE
         exclude:
           # Prune redundant checks (the go-next test needs only run once per platform)
+          - go-version: '1.21'
+            go-tags: 'go1.23'
+          - go-version: '1.21'
+            go-tags: 'datadog.no_waf,go1.23'
           - go-version: '1.20'
-            go-tags: go1.22
+            go-tags: 'go1.23'
           - go-version: '1.20'
-            go-tags: datadog.no_waf,go1.22
-          - go-version: '1.19'
-            go-tags: go1.22
-          - go-version: '1.19'
-            go-tags: datadog.no_waf,go1.22
+            go-tags: 'datadog.no_waf,go1.23'
           # Prune redundant checks (the appsec build tag is only relevant with cgo-enabled=0)
           - cgo-enabled: 1
             go-tags: "appsec"
           - cgo-enabled: 1
-            go-tags: "appsec,go1.22"
+            go-tags: "appsec,go1.23"
     name: ${{ matrix.runs-on }} go${{ matrix.go-version }} ${{ matrix.cgo-enabled == '1' && 'CGO' || 'noCGO' }} tags=${{  matrix.go-tags != '' && matrix.go-tags || '∅'  }} waf-log-level=${{ matrix.waf-log-level || 'OFF' }}
     runs-on: ${{ matrix.runs-on }}
     steps:

--- a/.github/workflows/_test_bare_metal.yml
+++ b/.github/workflows/_test_bare_metal.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04, windows-latest ]
-        go-version: [ "1.22-rc.1", "1.21", "1.20" ]
+        go-version: [ "1.22-rc.2", "1.21", "1.20" ]
         cgo-enabled: [ "0", "1" ] # test it compiles with and without cgo
         go-tags:
           - ''                      # Default behavior
@@ -22,7 +22,7 @@ jobs:
           # gocheck2 is configured differently in go1.21 than in previous versions
           - go-version: '1.21'
             go-experiment: cgocheck2
-          - go-version: '1.22'
+          - go-version: '1.22-rc.2'
             go-experiment: cgocheck2
           - go-version: '1.20'
             go-debug: cgocheck=2

--- a/.github/workflows/_test_bare_metal.yml
+++ b/.github/workflows/_test_bare_metal.yml
@@ -45,11 +45,11 @@ jobs:
             go-tags: "appsec"
           - cgo-enabled: 1
             go-tags: "appsec,go1.23"
-    name: ${{ matrix.runs-on }} go${{ matrix.go-version }} ${{ matrix.cgo-enabled == '1' && 'CGO' || 'noCGO' }} tags=${{  matrix.go-tags != '' && matrix.go-tags || '∅'  }} waf-log-level=${{ matrix.waf-log-level || 'OFF' }}
+    name: ${{ toJSON(matrix) }}
     runs-on: ${{ matrix.runs-on }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
           cache: true

--- a/.github/workflows/_test_containerized.yml
+++ b/.github/workflows/_test_containerized.yml
@@ -16,7 +16,7 @@ jobs:
           # RPM-based image
           - amazonlinux:2 # pretty popular on AWS workloads
         arch: [ amd64 ] # arm64 is manually included until github provides runners and to avoid long qemu exec times
-        go-version: [ "1.22rc", "1.21", "1.20", "1.19" ]
+        go-version: [ "1.22rc1", "1.21", "1.20", "1.19" ]
         cgo-enabled: [ "0", "1" ] # test it compiles with and without cgo
         go-tags:
           - ''                      # Default behavior
@@ -39,8 +39,9 @@ jobs:
             go-tags: ''
             waf-log-level: TRACE
             waf-timeout: 30s # Increase the timeout (especially in QEMU emulated modes)
+          # Test arm64 on a subset of the matrix for now to make it quicker to run due to qemu
           - arch: arm64
-            image: golang:alpine
+            image: golang:{0}-alpine
 
         exclude:
           # Prune redundant checks (the go-next test needs only run once per platform)

--- a/.github/workflows/_test_containerized.yml
+++ b/.github/workflows/_test_containerized.yml
@@ -16,7 +16,7 @@ jobs:
           # RPM-based image
           - amazonlinux:2 # pretty popular on AWS workloads
         arch: [ amd64 ] # arm64 is manually included until github provides runners and to avoid long qemu exec times
-        go-version: [ "1.22rc1", "1.21", "1.20", "1.19" ]
+        go-version: [ "1.22rc1", "1.21", "1.20" ]
         cgo-enabled: [ "0", "1" ] # test it compiles with and without cgo
         go-tags:
           - ''                      # Default behavior

--- a/.github/workflows/_test_containerized.yml
+++ b/.github/workflows/_test_containerized.yml
@@ -16,7 +16,7 @@ jobs:
           # RPM-based image
           - amazonlinux:2 # pretty popular on AWS workloads
         arch: [ amd64, arm64 ] # arm64 is manually included until github provides runners and to avoid long qemu exec times
-        go-version: [ "1.22rc1", "1.21", "1.20" ]
+        go-version: [ "1.22rc2", "1.21", "1.20" ]
         cgo-enabled: [ "0", "1" ] # test it compiles with and without cgo
         go-tags:
           - ''                      # Default behavior
@@ -30,12 +30,12 @@ jobs:
           # gocheck2 is configured differently in go1.21 than in previous versions
           - go-version: '1.21'
             go-experiment: cgocheck2
-          - go-version: '1.22'
+          - go-version: '1.22rc2'
             go-experiment: cgocheck2
           - go-version: '1.20'
             go-debug: cgocheck=2
           # Test with DD_APPSEC_WAF_LOG_LEVEL (only latest go, without any particular tag)
-          - go-version: '1.21'
+          - go-version: '1.22rc2'
             go-tags: ''
             waf-log-level: TRACE
             waf-timeout: 30s # Increase the timeout (especially in QEMU emulated modes)
@@ -64,12 +64,12 @@ jobs:
           - go-version: '1.21'
             image: golang:{0}-buster
            # Prune inexistant build images (debian buster is on LTS but won't get new go version images)
-          - go-version: '1.22rc1'
+          - go-version: '1.22rc2'
             image: golang:{0}-buster
           # The amazonlinux:2 variant is only relevant for the default go version yum ships (currently 1.20)
           - go-version: '1.21'
             image: amazonlinux:2
-          - go-version: '1.22'
+          - go-version: '1.22rc2'
             image: amazonlinux:2
     name: ${{ toJSON(matrix) }}
     runs-on: ubuntu-latest

--- a/.github/workflows/_test_containerized.yml
+++ b/.github/workflows/_test_containerized.yml
@@ -61,6 +61,9 @@ jobs:
           # Prune inexistant build images (debian buster is on LTS but won't get new go version images)
           - go-version: '1.21'
             image: golang:{0}-buster
+           # Prune inexistant build images (debian buster is on LTS but won't get new go version images)
+          - go-version: '1.22rc1'
+            image: golang:{0}-buster
           # The amazonlinux:2 variant is only relevant for the default go version yum ships (currently 1.20)
           - go-version: '1.19'
             image: amazonlinux:2

--- a/.github/workflows/_test_containerized.yml
+++ b/.github/workflows/_test_containerized.yml
@@ -8,14 +8,14 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          # Standard golang image
+          # Standard golang images
           - golang:{0}-alpine
           - golang:{0}-bookworm
           - golang:{0}-bullseye
           - golang:{0}-buster
           # RPM-based image
           - amazonlinux:2 # pretty popular on AWS workloads
-        arch: [ amd64 ] # arm64 is manually included until github provides runners and to avoid long qemu exec times
+        arch: [ amd64, arm64 ] # arm64 is manually included until github provides runners and to avoid long qemu exec times
         go-version: [ "1.22rc1", "1.21", "1.20" ]
         cgo-enabled: [ "0", "1" ] # test it compiles with and without cgo
         go-tags:
@@ -23,41 +23,43 @@ jobs:
           - 'datadog.no_waf'        # Explicitly disabled WAF
           - 'appsec'                # Legacy build tag to enable appsec when cgo is disabled
           - 'appsec,datadog.no_waf' # An awkward combination that must nevertheless compile
-          - 'go1.22'                # Too recent go version (purego compatibility uncertain)
-          - 'datadog.no_waf,go1.22' # Explicitly disabled & too recent go version (purego compatibility uncertain)
-          - 'appsec,go1.22'         # Explicitly enabled w/o cgo & too recent go version (purego compatibility uncertain)
+          - 'go1.23'                # Too recent go version (purego compatibility uncertain)
+          - 'datadog.no_waf,go1.23' # Explicitly disabled & too recent go version (purego compatibility uncertain)
+          - 'appsec,go1.23'         # Explicitly enabled w/o cgo & too recent go version (purego compatibility uncertain)
         include:
           # gocheck2 is configured differently in go1.21 than in previous versions
           - go-version: '1.21'
             go-experiment: cgocheck2
+          - go-version: '1.22'
+            go-experiment: cgocheck2
           - go-version: '1.20'
-            go-debug: cgocheck=2
-          - go-version: '1.19'
             go-debug: cgocheck=2
           # Test with DD_APPSEC_WAF_LOG_LEVEL (only latest go, without any particular tag)
           - go-version: '1.21'
             go-tags: ''
             waf-log-level: TRACE
             waf-timeout: 30s # Increase the timeout (especially in QEMU emulated modes)
-          # Test arm64 on a subset of the matrix for now to make it quicker to run due to qemu
-          - arch: arm64
-            image: golang:{0}-alpine
 
         exclude:
+          # Test arm64 on a subset of the matrix for now to make it quicker to run due to qemu
+          - arch: arm64
+            image: golang:{0}-buster
+          - arch: arm64
+            image: golang:{0}-bullseye
           # Prune redundant checks (the go-next test needs only run once per platform)
+          - go-version: '1.21'
+            go-tags: 'go1.23'
+          - go-version: '1.21'
+            go-tags: 'datadog.no_waf,go1.23'
           - go-version: '1.20'
-            go-tags: go1.22
+            go-tags: 'go1.23'
           - go-version: '1.20'
-            go-tags: datadog.no_waf,go1.22
-          - go-version: '1.19'
-            go-tags: go1.22
-          - go-version: '1.19'
-            go-tags: datadog.no_waf,go1.22
+            go-tags: 'datadog.no_waf,go1.23'
           # Prune redundant checks (the appsec build tag is only relevant with cgo-enabled=0)
           - cgo-enabled: 1
             go-tags: "appsec"
           - cgo-enabled: 1
-            go-tags: "appsec,go1.22"
+            go-tags: "appsec,go1.23"
           # Prune inexistant build images (debian buster is on LTS but won't get new go version images)
           - go-version: '1.21'
             image: golang:{0}-buster
@@ -65,11 +67,11 @@ jobs:
           - go-version: '1.22rc1'
             image: golang:{0}-buster
           # The amazonlinux:2 variant is only relevant for the default go version yum ships (currently 1.20)
-          - go-version: '1.19'
-            image: amazonlinux:2
           - go-version: '1.21'
             image: amazonlinux:2
-    name: ${{ format(matrix.image, matrix.go-version) }} ${{ matrix.arch }} ${{ matrix.cgo-enabled == '1' && 'CGO' || 'noCGO' }} tags=${{ matrix.go-tags != '' && matrix.go-tags || '∅' }} waf-log-level=${{ matrix.waf-log-level || 'OFF' }}
+          - go-version: '1.22'
+            image: amazonlinux:2
+    name: ${{ toJSON(matrix) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/_test_containerized.yml
+++ b/.github/workflows/_test_containerized.yml
@@ -15,8 +15,8 @@ jobs:
           - golang:{0}-buster
           # RPM-based image
           - amazonlinux:2 # pretty popular on AWS workloads
-        arch: [ amd64, arm64 ]
-        go-version: [ "1.21", "1.20", "1.19" ]
+        arch: [ amd64 ] # arm64 is manually included until github provides runners and to avoid long qemu exec times
+        go-version: [ "1.22rc", "1.21", "1.20", "1.19" ]
         cgo-enabled: [ "0", "1" ] # test it compiles with and without cgo
         go-tags:
           - ''                      # Default behavior
@@ -39,6 +39,8 @@ jobs:
             go-tags: ''
             waf-log-level: TRACE
             waf-timeout: 30s # Increase the timeout (especially in QEMU emulated modes)
+          - arch: arm64
+            image: golang:alpine
 
         exclude:
           # Prune redundant checks (the go-next test needs only run once per platform)

--- a/.github/workflows/_test_containerized.yml
+++ b/.github/workflows/_test_containerized.yml
@@ -15,7 +15,7 @@ jobs:
           - golang:{0}-buster
           # RPM-based image
           - amazonlinux:2 # pretty popular on AWS workloads
-        arch: [ amd64, arm64 ] # arm64 is manually included until github provides runners and to avoid long qemu exec times
+        arch: [ amd64, arm64 ]
         go-version: [ "1.22rc2", "1.21", "1.20" ]
         cgo-enabled: [ "0", "1" ] # test it compiles with and without cgo
         go-tags:
@@ -74,7 +74,7 @@ jobs:
     name: ${{ toJSON(matrix) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod

--- a/.github/workflows/_test_containerized.yml
+++ b/.github/workflows/_test_containerized.yml
@@ -81,7 +81,7 @@ jobs:
           key: go-pkg-mod-${{ hashFiles('**/go.sum') }}
           restore-keys: go-pkg-mod-
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: ${{ matrix.arch }}
       - name: Create container

--- a/.github/workflows/_test_containerized.yml
+++ b/.github/workflows/_test_containerized.yml
@@ -60,10 +60,10 @@ jobs:
             go-tags: "appsec"
           - cgo-enabled: 1
             go-tags: "appsec,go1.23"
-          # Prune inexistant build images (debian buster is on LTS but won't get new go version images)
+          # Prune inexistent build images (debian buster is on LTS but won't get new go version images)
           - go-version: '1.21'
             image: golang:{0}-buster
-           # Prune inexistant build images (debian buster is on LTS but won't get new go version images)
+           # Prune inexistent build images (debian buster is on LTS but won't get new go version images)
           - go-version: '1.22rc2'
             image: golang:{0}-buster
           # The amazonlinux:2 variant is only relevant for the default go version yum ships (currently 1.20)
@@ -75,13 +75,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: go-pkg-mod-${{ hashFiles('**/go.sum') }}
           restore-keys: go-pkg-mod-
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: ${{ matrix.arch }}
       - name: Create container

--- a/_tools/libddwaf-updater/update.go
+++ b/_tools/libddwaf-updater/update.go
@@ -31,7 +31,7 @@ var (
 )
 
 const (
-	goVersionUnsupported = "go1.22"
+	goVersionUnsupported = "go1.23"
 )
 
 func main() {

--- a/ctypes_test.go
+++ b/ctypes_test.go
@@ -4,7 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Purego only works on linux/macOS with amd64 and arm64 from now
-//go:build (linux || darwin) && (amd64 || arm64) && !go1.22 && !datadog.no_waf && (cgo || appsec)
+//go:build (linux || darwin) && (amd64 || arm64) && !go1.23 && !datadog.no_waf && (cgo || appsec)
 
 package waf
 

--- a/encoder_decoder_test.go
+++ b/encoder_decoder_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (amd64 || arm64) && (linux || darwin) && !go1.22 && !datadog.no_waf && (cgo || appsec)
+//go:build (amd64 || arm64) && (linux || darwin) && !go1.23 && !datadog.no_waf && (cgo || appsec)
 
 package waf
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/go-libddwaf/v2
 
-go 1.19
+go 1.20
 
 require (
 	github.com/ebitengine/purego v0.5.2

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/sys v0.13.0 // indirect
+	golang.org/x/sys v0.16.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/DataDog/go-libddwaf/v2
 go 1.20
 
 require (
-	github.com/ebitengine/purego v0.5.2
+	github.com/ebitengine/purego v0.6.0-alpha.5
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/ebitengine/purego v0.5.2 h1:r2MQEtkGzZ4LRtFZVAg5bjYKnUbxxloaeuGxH0t7qfs=
-github.com/ebitengine/purego v0.5.2/go.mod h1:ah1In8AOtksoNK6yk5z1HTJeUkC1Ez4Wk2idgGslMwQ=
+github.com/ebitengine/purego v0.6.0-alpha.5 h1:EYID3JOAdmQ4SNZYJHu9V6IqOeRQDBYxqKAg9PyoHFY=
+github.com/ebitengine/purego v0.6.0-alpha.5/go.mod h1:ah1In8AOtksoNK6yk5z1HTJeUkC1Ez4Wk2idgGslMwQ=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
-golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
-golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
+golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build ((darwin && (amd64 || arm64)) || (linux && (amd64 || arm64))) && !go1.22 && !datadog.no_waf && (cgo || appsec)
+//go:build ((darwin && (amd64 || arm64)) || (linux && (amd64 || arm64))) && !go1.23 && !datadog.no_waf && (cgo || appsec)
 
 package lib
 

--- a/internal/lib/lib_darwin_amd64.go
+++ b/internal/lib/lib_darwin_amd64.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build darwin && amd64 && !go1.22 && !datadog.no_waf && (cgo || appsec)
+//go:build darwin && amd64 && !go1.23 && !datadog.no_waf && (cgo || appsec)
 
 package lib
 

--- a/internal/lib/lib_darwin_arm64.go
+++ b/internal/lib/lib_darwin_arm64.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build darwin && arm64 && !go1.22 && !datadog.no_waf && (cgo || appsec)
+//go:build darwin && arm64 && !go1.23 && !datadog.no_waf && (cgo || appsec)
 
 package lib
 

--- a/internal/lib/lib_linux_amd64.go
+++ b/internal/lib/lib_linux_amd64.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux && amd64 && !go1.22 && !datadog.no_waf && (cgo || appsec)
+//go:build linux && amd64 && !go1.23 && !datadog.no_waf && (cgo || appsec)
 
 package lib
 

--- a/internal/lib/lib_linux_arm64.go
+++ b/internal/lib/lib_linux_arm64.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux && arm64 && !go1.22 && !datadog.no_waf && (cgo || appsec)
+//go:build linux && arm64 && !go1.23 && !datadog.no_waf && (cgo || appsec)
 
 package lib
 

--- a/internal/log/log_purego.go
+++ b/internal/log/log_purego.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !cgo && (darwin || freebsd) && !datadog.no_waf && !go1.22
+//go:build !cgo && (darwin || freebsd) && !datadog.no_waf && !go1.23
 
 package log
 

--- a/internal/log/log_unsupported.go
+++ b/internal/log/log_unsupported.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (!cgo && ((!darwin && !freebsd) || go1.22)) || datadog.no_waf
+//go:build (!cgo && ((!darwin && !freebsd) || go1.23)) || datadog.no_waf
 
 package log
 

--- a/symbols_linux_cgo.go
+++ b/symbols_linux_cgo.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build cgo && linux && !go1.22 && !datadog.no_waf
+//go:build cgo && linux && !go1.23 && !datadog.no_waf
 
 package waf
 

--- a/symbols_linux_purego.go
+++ b/symbols_linux_purego.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !cgo && appsec && linux && !go1.22 && !datadog.no_waf
+//go:build !cgo && appsec && linux && !go1.23 && !datadog.no_waf
 
 package waf
 

--- a/waf_dl.go
+++ b/waf_dl.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (linux || darwin) && (amd64 || arm64) && !go1.22 && !datadog.no_waf && (cgo || appsec)
+//go:build (linux || darwin) && (amd64 || arm64) && !go1.23 && !datadog.no_waf && (cgo || appsec)
 
 package waf
 

--- a/waf_dl_test.go
+++ b/waf_dl_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (linux || darwin) && (amd64 || arm64) && !go1.22 && !datadog.no_waf && (cgo || appsec)
+//go:build (linux || darwin) && (amd64 || arm64) && !go1.23 && !datadog.no_waf && (cgo || appsec)
 
 package waf
 

--- a/waf_dl_unsupported.go
+++ b/waf_dl_unsupported.go
@@ -4,7 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Build when the target OS or architecture are not supported
-//go:build (!linux && !darwin) || (!amd64 && !arm64) || go1.22 || datadog.no_waf || (!cgo && !appsec)
+//go:build (!linux && !darwin) || (!amd64 && !arm64) || go1.23 || datadog.no_waf || (!cgo && !appsec)
 
 package waf
 

--- a/waf_test.go
+++ b/waf_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (amd64 || arm64) && (linux || darwin) && !go1.22 && !datadog.no_waf && (cgo || appsec)
+//go:build (amd64 || arm64) && (linux || darwin) && !go1.23 && !datadog.no_waf && (cgo || appsec)
 
 package waf
 

--- a/waf_unsupported_go.go
+++ b/waf_unsupported_go.go
@@ -4,7 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Unsupported Go versions (>=)
-//go:build go1.22
+//go:build go1.23
 
 package waf
 

--- a/waf_unsupported_go_test.go
+++ b/waf_unsupported_go_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build go1.22
+//go:build go1.23
 
 package waf_test
 


### PR DESCRIPTION
- [x] CI: make it faster with less qemu arm64 tests untils GitHub introduces proper arm64 runners
- [x] CI: add go1.22 to the list of go versions to test
- [x] Unlock go1.22 from the build tags

APPSEC-32982