### PR TITLE
feat(encoder): coerce aliases of byte slices as byte slices

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -165,7 +165,7 @@ func (encoder *encoder) encode(value reflect.Value, obj *wafObject, depth int) e
 	case kind == reflect.String: // string type
 		encoder.encodeString(value.String(), obj)
 
-	case value.Type() == reflect.TypeOf([]byte(nil)):
+	case (kind == reflect.Array || kind == reflect.Slice) && value.Type().Elem().Kind() == reflect.Uint8:
 		// Byte Arrays are skipped voluntarily because they are often used
 		// to do partial parsing which leads to false positives
 		return nil

--- a/encoder_decoder_test.go
+++ b/encoder_decoder_test.go
@@ -9,6 +9,7 @@ package waf
 
 import (
 	"context"
+	"encoding/json"
 	"reflect"
 	"sort"
 	"testing"
@@ -130,6 +131,11 @@ func TestEncodeDecode(t *testing.T) {
 		{
 			Name:        "byte-slice",
 			Input:       []byte("hello, waf"),
+			DecodeError: errUnsupportedValue,
+		},
+		{
+			Name:        "json-raw",
+			Input:       json.RawMessage("hello, waf"),
 			DecodeError: errUnsupportedValue,
 		},
 		{
@@ -260,11 +266,13 @@ func TestEncodeDecode(t *testing.T) {
 				private string
 				a       string
 				A       string
+				partial json.RawMessage
 			}{
 				Public:  "Public",
 				private: "private",
 				a:       "a",
 				A:       "A",
+				partial: json.RawMessage("test"),
 			},
 			Output: map[string]any{
 				"A": "A",


### PR DESCRIPTION
One of the sources of false positives are partial parsing using `json.RawMessage` for json parsing for example. Ignoring these kind of values during encoding makes the WAF more reliable and faster in case different types of byte slice aliases are present