### PR TITLE
ci: tranfer part of the matrix to a shell script

### DIFF
--- a/.github/workflows/_test_bare_metal.yml
+++ b/.github/workflows/_test_bare_metal.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ macos-14, macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04, ubuntu-latest-16-cores, windows-latest ]
-        go-version: [ "1.22.0", "1.21", "1.20", "1.19" ]
+        go-version: [ "1.22", "1.21", "1.20", "1.19" ]
         include:
           # Test with DD_APPSEC_WAF_LOG_LEVEL (only latest go, without any particular tag)
           - go-version: '1.22'

--- a/.github/workflows/_test_bare_metal.yml
+++ b/.github/workflows/_test_bare_metal.yml
@@ -7,10 +7,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ macos-14, macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04, ubuntu-latest-16-cores, windows-latest ]
+        runs-on: [ macos-14, macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04, windows-latest ]
         go-version: [ "1.22", "1.21", "1.20", "1.19" ]
         include:
-          # Test with DD_APPSEC_WAF_LOG_LEVEL (only latest go, without any particular tag)
+          # Test with DD_APPSEC_WAF_LOG_LEVEL (only latest go version)
           - go-version: '1.22'
             waf-log-level: TRACE
     name: ${{ toJSON(matrix) }}

--- a/.github/workflows/_test_bare_metal.yml
+++ b/.github/workflows/_test_bare_metal.yml
@@ -7,44 +7,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ macos-14, macos-13, macos-12, ubuntu-22.04, ubuntu-20.04, windows-latest ]
-        go-version: [ "1.22.0-rc.2", "1.21", "1.20" ]
-        cgo-enabled: [ "0", "1" ] # test it compiles with and without cgo
-        go-tags:
-          - ''                      # Default behavior
-          - 'datadog.no_waf'        # Explicitly disabled WAF
-          - 'go1.23'                # Too recent go version (purego compatibility uncertain)
-          - 'appsec'                # Legacy build tag to enable appsec when cgo is disabled
-          - 'appsec,datadog.no_waf' # An awkward combination that must nevertheless compile
-          - 'datadog.no_waf,go1.23' # Explicitly disabled & too recent go version (purego compatibility uncertain)
-          - 'appsec,go1.23'         # Explicitly enabled w/o cgo & too recent go version (purego compatibility uncertain)
+        runs-on: [ macos-14, macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04, ubuntu-latest-16-cores, windows-latest ]
+        go-version: [ "1.22.0", "1.21", "1.20", "1.19" ]
         include:
-          # gocheck2 is configured differently in go1.21 than in previous versions
-          - go-version: '1.21'
-            go-experiment: cgocheck2
-          - go-version: '1.22.0-rc.2'
-            go-experiment: cgocheck2
-          - go-version: '1.20'
-            go-debug: cgocheck=2
           # Test with DD_APPSEC_WAF_LOG_LEVEL (only latest go, without any particular tag)
-          - go-version: '1.21'
-            go-tags: ''
+          - go-version: '1.22'
             waf-log-level: TRACE
-        exclude:
-          # Prune redundant checks (the go-next test needs only run once per platform)
-          - go-version: '1.21'
-            go-tags: 'go1.23'
-          - go-version: '1.21'
-            go-tags: 'datadog.no_waf,go1.23'
-          - go-version: '1.20'
-            go-tags: 'go1.23'
-          - go-version: '1.20'
-            go-tags: 'datadog.no_waf,go1.23'
-          # Prune redundant checks (the appsec build tag is only relevant with cgo-enabled=0)
-          - cgo-enabled: 1
-            go-tags: "appsec"
-          - cgo-enabled: 1
-            go-tags: "appsec,go1.23"
     name: ${{ toJSON(matrix) }}
     runs-on: ${{ matrix.runs-on }}
     steps:
@@ -57,14 +25,6 @@ jobs:
         run: go install gotest.tools/gotestsum@latest
       - name: go test
         shell: bash
-        run: |-
-          gotestsum -- -v -count=10 -shuffle=on -tags='${{ matrix.go-tags }}' ./...
+        run: ./.github/workflows/ci.sh
         env:
-          CGO_ENABLED: ${{ matrix.cgo-enabled }}
-          # libddwaf's DEBUG is pretty spammy, and higher log levels don't happen in normal operations... and log
-          # overhead can make tests time out if we don't filter out DEBUG to reduce thrash!
-          DD_APPSEC_WAF_LOG_FILTER: "@ waf[.]cpp:"
           DD_APPSEC_WAF_LOG_LEVEL: ${{ matrix.waf-log-level }}
-          DD_APPSEC_WAF_TIMEOUT: 5s
-          GODEBUG: ${{ matrix.go-debug }}
-          GOEXPERIMENT: ${{ matrix.go-experiment }}

--- a/.github/workflows/_test_containerized.yml
+++ b/.github/workflows/_test_containerized.yml
@@ -16,60 +16,29 @@ jobs:
           # RPM-based image
           - amazonlinux:2 # pretty popular on AWS workloads
         arch: [ amd64, arm64 ]
-        go-version: [ "1.22rc2", "1.21", "1.20" ]
-        cgo-enabled: [ "0", "1" ] # test it compiles with and without cgo
-        go-tags:
-          - ''                      # Default behavior
-          - 'datadog.no_waf'        # Explicitly disabled WAF
-          - 'appsec'                # Legacy build tag to enable appsec when cgo is disabled
-          - 'appsec,datadog.no_waf' # An awkward combination that must nevertheless compile
-          - 'go1.23'                # Too recent go version (purego compatibility uncertain)
-          - 'datadog.no_waf,go1.23' # Explicitly disabled & too recent go version (purego compatibility uncertain)
-          - 'appsec,go1.23'         # Explicitly enabled w/o cgo & too recent go version (purego compatibility uncertain)
+        go-version: [ "1.22", "1.21", "1.20", "1.19" ]
         include:
-          # gocheck2 is configured differently in go1.21 than in previous versions
-          - go-version: '1.21'
-            go-experiment: cgocheck2
-          - go-version: '1.22rc2'
-            go-experiment: cgocheck2
-          - go-version: '1.20'
-            go-debug: cgocheck=2
           # Test with DD_APPSEC_WAF_LOG_LEVEL (only latest go, without any particular tag)
-          - go-version: '1.22rc2'
-            go-tags: ''
+          - go-version: '1.22'
             waf-log-level: TRACE
-            waf-timeout: 30s # Increase the timeout (especially in QEMU emulated modes)
-
         exclude:
           # Test arm64 on a subset of the matrix for now to make it quicker to run due to qemu
           - arch: arm64
             image: golang:{0}-buster
           - arch: arm64
             image: golang:{0}-bullseye
-          # Prune redundant checks (the go-next test needs only run once per platform)
-          - go-version: '1.21'
-            go-tags: 'go1.23'
-          - go-version: '1.21'
-            go-tags: 'datadog.no_waf,go1.23'
-          - go-version: '1.20'
-            go-tags: 'go1.23'
-          - go-version: '1.20'
-            go-tags: 'datadog.no_waf,go1.23'
-          # Prune redundant checks (the appsec build tag is only relevant with cgo-enabled=0)
-          - cgo-enabled: 1
-            go-tags: "appsec"
-          - cgo-enabled: 1
-            go-tags: "appsec,go1.23"
           # Prune inexistent build images (debian buster is on LTS but won't get new go version images)
           - go-version: '1.21'
             image: golang:{0}-buster
            # Prune inexistent build images (debian buster is on LTS but won't get new go version images)
-          - go-version: '1.22rc2'
+          - go-version: '1.22'
             image: golang:{0}-buster
           # The amazonlinux:2 variant is only relevant for the default go version yum ships (currently 1.20)
+          - go-version: '1.19'
+            image: amazonlinux:2
           - go-version: '1.21'
             image: amazonlinux:2
-          - go-version: '1.22rc2'
+          - go-version: '1.22'
             image: amazonlinux:2
     name: ${{ toJSON(matrix) }}
     runs-on: ubuntu-latest
@@ -81,9 +50,10 @@ jobs:
           key: go-pkg-mod-${{ hashFiles('**/go.sum') }}
           restore-keys: go-pkg-mod-
       - name: Set up QEMU
+        if: matrix.arch == 'arm64'
         uses: docker/setup-qemu-action@v3
         with:
-          platforms: ${{ matrix.arch }}
+          platforms: arm64
       - name: Create container
         id: container
         run: |-
@@ -92,34 +62,17 @@ jobs:
             -v "${HOME}/go/pkg/mod:/go/pkg/mod"                                 \
             -v "$PWD:$PWD"                                                      \
             -w "$PWD"                                                           \
-            -eCGO_ENABLED="${{ matrix.cgo-enabled }}"                           \
-            -eDD_APPSEC_WAF_LOG_FILTER="@ waf[.]cpp:"                           \
             -eDD_APPSEC_WAF_LOG_LEVEL="${{ matrix.waf-log-level }}"             \
-            -eDD_APPSEC_WAF_TIMEOUT="${{ matrix.waf-timeout || '5s' }}"         \
-            -eGODEBUG="${{ matrix.go-debug }}"                                  \
-            -eGOEXPERIMENT="${{ matrix.go-experiment }}"                        \
             -eGOMODCACHE="/go/pkg/mod"                                          \
             "${{ format(matrix.image, matrix.go-version) }}"
-      - name: Install alpine requirements
-        if: endsWith(matrix.image, '-alpine') && matrix.cgo-enabled == '1'
-        run: |-
-          docker exec -i gha-${{ github.run_id }}                               \
-            apk add gcc musl-dev libc6-compat
       - name: Install AmazonLinux 2 requirements
         if: matrix.image == 'amazonlinux:2'
         run: |-
           docker exec -i gha-${{ github.run_id }}                               \
             yum install -y golang
-      - name: Install gotestsum
+      - name: Run the ci.sh script
         run: |-
-          docker exec -i gha-${{ github.run_id }}                               \
-            go install gotest.tools/gotestsum@latest
-      - name: go test
-        run: |-
-          docker exec -i gha-${{ github.run_id }}                               \
-            go run gotest.tools/gotestsum@latest --                             \
-              -v -count=10 -shuffle=on -tags='${{ matrix.go-tags }}'             \
-              ./...
+          docker exec -i gha-${{ github.run_id }} $PWD/.github/workflows/ci.sh
       - name: Stop container
         if: always() && steps.container.outcome == 'success'
         run: |-

--- a/.github/workflows/ci.sh
+++ b/.github/workflows/ci.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-export DD_APPSEC_WAF_TIMEOUT=1m
+export DD_APPSEC_WAF_TIMEOUT=10m
 export DD_APPSEC_WAF_LOG_FILTER="@ waf[.]cpp:"
 
 # Read all go env and os variables as shell variables

--- a/.github/workflows/ci.sh
+++ b/.github/workflows/ci.sh
@@ -61,6 +61,6 @@ if [ -f /etc/os-release ] && grep -q Alpine < /etc/os-release; then
 fi
 
 run "$WAF_ENABLED" cgo                   # WAF enabled (but not on windows)
-run false go1.23,cgo                     # CGO disabled and too recent go version
-run false datadog.no_waf,cgo             # WAF manually disabled and CGO disabled
-run false datadog.no_waf,go1.23,cgo      # CGO disabled, WAF manually disabled, too recent go version
+run false go1.23,cgo                     # CGO enabled and too recent go version
+run false datadog.no_waf,cgo             # WAF manually disabled and CGO enabled
+run false datadog.no_waf,go1.23,cgo      # CGO enabled, WAF manually disabled, too recent go version

--- a/.github/workflows/ci.sh
+++ b/.github/workflows/ci.sh
@@ -1,0 +1,59 @@
+#!/bin/sh -e
+
+export DD_APPSEC_WAF_TIMEOUT=1m
+export DD_APPSEC_WAF_LOG_FILTER="@ waf[.]cpp:"
+
+# Read all go env and os variables as shell variables
+# shellcheck disable=SC2046
+eval $(go env)
+
+case $GOVERSION in
+    *1.20*|*1.19* )
+        export GODEBUG=cgocheck=2
+        ;;
+    *)
+        export GOEXPERIMENT=cgocheck2
+esac
+
+# Return true if the current OS is not Windows
+WAF_ENABLED=$([ "$GOOS" = "windows" ] && echo false || echo true)
+
+# run is tne main function that runs the tests
+# It takes 2 arguments:
+# - $1: whether the WAF is enabled or not (true or false)
+# - $2: the tags to use for the tests (e.g. "appsec,cgo")
+run() {
+    waf_enabled="$1"
+    tags="ci,$(echo "$2" | sed 's/cgo//')"
+    nproc=$(nproc)
+    test_tags="$2,$GOOS,$GOARCH"
+    cgo=$(case "$2" in *"cgo"*) echo 1;; *) echo 0;; esac)
+
+    set -x
+    CGO_ENABLED=$cgo go run gotest.tools/gotestsum@v1.11.0 -- -v -shuffle=on -tags="$tags" -args -waf-build-tags="$test_tags" -waf-supported="$waf_enabled" ./...
+    set +x
+
+    # Do multiple runs in parralel only in case the WAF is enabled
+    if $waf_enabled; then
+       CGO_ENABLED=$cgo go run gotest.tools/gotestsum@v1.11.0 -- -v -shuffle=on -parallel $((nproc / 4)) -count="$nproc" -tags="$tags" -args -waf-build-tags="$test_tags" -waf-supported="$waf_enabled" ./...
+    fi
+}
+
+run "$WAF_ENABLED" appsec                # WAF enabled (but not on windows)
+run false                                # CGO Disabled
+run false go1.23                         # Too recent go version (not tested)
+run false go1.23,appsec                  # CGO disabled with appsec explicitely enabled but too recent go version
+run false datadog.no_waf                 # WAF manually disabled
+run false datadog.no_waf,appsec          # CGO disabled with appsec explicitely enabled but WAF manually disabled
+run false datadog.no_waf,go1.23          # WAF manually disabled and go version to recent
+run false datadog.no_waf,go1.23,appsec   # CGO disabled, WAF manually disabled, too recent go version with appsec explicitely enabled
+
+# Check if we are running on Alpine and install the required dependencies for cgo
+if [ -f /etc/os-release ] && grep -q Alpine < /etc/os-release; then
+  apk add gcc musl-dev libc6-compat
+fi
+
+run "$WAF_ENABLED" cgo                   # WAF enabled (but not on windows)
+run false go1.23,cgo                     # CGO disabled and too recent go version
+run false datadog.no_waf,cgo             # WAF manually disabled and CGO disabled
+run false datadog.no_waf,go1.23,cgo      # CGO disabled, WAF manually disabled, too recent go version

--- a/encoder.go
+++ b/encoder.go
@@ -75,7 +75,7 @@ func (encoder *encoder) Encode(data any) (wo *wafObject, err error) {
 
 	err = encoder.encode(value, wo, encoder.objectMaxDepth)
 	if len(encoder.truncations[ObjectTooDeep]) != 0 {
-		encoder.measureObjectDepth(value)
+		encoder.measureObjectDepth(value, time.Millisecond)
 	}
 
 	return
@@ -390,8 +390,8 @@ func (encoder *encoder) addTruncation(reason TruncationReason, size int) {
 // mesureObjectDepth traverses the provided object recursively to try and obtain
 // the real object depth, but limits itself to about 1ms of time budget, past
 // which it'll stop and return whatever it has go to so far.
-func (encoder *encoder) measureObjectDepth(obj reflect.Value) {
-	ctx, cancelCtx := context.WithTimeout(context.Background(), time.Millisecond)
+func (encoder *encoder) measureObjectDepth(obj reflect.Value, timeout time.Duration) {
+	ctx, cancelCtx := context.WithTimeout(context.Background(), timeout)
 	defer cancelCtx()
 
 	depth, _ := depthOf(ctx, obj)

--- a/encoder_decoder_test.go
+++ b/encoder_decoder_test.go
@@ -532,7 +532,12 @@ func TestEncoderLimits(t *testing.T) {
 			containerMaxSize: maxContainerLength,
 		}
 
-		encoded, err := encoder.Encode(tc.Input)
+		value := reflect.ValueOf(tc.Input)
+		encoded := &wafObject{}
+		err := encoder.encode(value, encoded, encoder.objectMaxDepth)
+		if len(encoder.truncations[ObjectTooDeep]) != 0 {
+			encoder.measureObjectDepth(value, time.Second) // Stupid-sized timeout for slow arm CI runners
+		}
 
 		t.Run(tc.Name+"/assert", func(t *testing.T) {
 			require.Equal(t, tc.Truncations, sortValues(encoder.Truncations()))
@@ -835,7 +840,7 @@ func TestResolvePointer(t *testing.T) {
 
 func TestDepthOf(t *testing.T) {
 	t.Run("is safe with self-referecing structs", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*10)
 		defer cancel()
 
 		type selfReferencing struct {

--- a/encoder_decoder_test.go
+++ b/encoder_decoder_test.go
@@ -536,7 +536,7 @@ func TestEncoderLimits(t *testing.T) {
 		encoded := &wafObject{}
 		err := encoder.encode(value, encoded, encoder.objectMaxDepth)
 		if len(encoder.truncations[ObjectTooDeep]) != 0 {
-			encoder.measureObjectDepth(value, time.Second) // Stupid-sized timeout for slow arm CI runners
+			encoder.measureObjectDepth(value, time.Hour) // Stupid-sized timeout for slow arm CI runners
 		}
 
 		t.Run(tc.Name+"/assert", func(t *testing.T) {

--- a/handle_test.go
+++ b/handle_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build (amd64 || arm64) && (linux || darwin) && !go1.23 && !datadog.no_waf && (cgo || appsec)
+
 package waf
 
 import (

--- a/waf_support.go
+++ b/waf_support.go
@@ -7,8 +7,6 @@ package waf
 
 import (
 	"fmt"
-	"runtime"
-
 	"github.com/hashicorp/go-multierror"
 )
 
@@ -32,10 +30,12 @@ func (e UnsupportedOSArchError) Error() string {
 
 // UnsupportedGoVersionError is a wrapper error type helping to handle the error
 // case of trying to execute this package when the Go version is not supported.
-type UnsupportedGoVersionError struct{}
+type UnsupportedGoVersionError struct {
+	Version string
+}
 
 func (e UnsupportedGoVersionError) Error() string {
-	return fmt.Sprintf("unsupported Go version: %s", runtime.Version())
+	return fmt.Sprintf("unsupported Go version: %s", e.Version)
 }
 
 type CgoDisabledError struct{}

--- a/waf_support_test.go
+++ b/waf_support_test.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build ci
+
+package waf
+
+import (
+	"flag"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var (
+	wafSupportedFlag *bool
+	wafBuildTags     *string
+)
+
+func init() {
+	wafSupportedFlag = flag.Bool("waf-supported", false, "Set to true if the WAF is supported on the current target")
+	wafBuildTags = flag.String("waf-build-tags", "", "Set to the build tags used to build the WAF")
+}
+
+// TestSupport is used to make sure the WAF is actually enabled and disabled when it respectively should be
+// using data send by the CI.
+func TestSupport(t *testing.T) {
+	require.NotNil(t, wafSupportedFlag, "The `waf-supported` flag should be set")
+	require.NotNil(t, wafBuildTags, "The `waf-build-tags` flag should be set")
+	require.NotEmpty(t, *wafBuildTags, "The `waf-build-tags` flag should not be empty")
+
+	errors := make([]error, len(wafSupportErrors))
+	copy(errors, wafSupportErrors)
+	if wafManuallyDisabledErr != nil {
+		errors = append(errors, wafManuallyDisabledErr)
+	}
+
+	ok, _ := Health()
+	require.Equal(t, *wafSupportedFlag, ok, "WAF support should match the value of the `waf-supported` flag in the CI")
+
+	if *wafSupportedFlag {
+		require.Empty(t, errors, "No errors should be returned when the WAF is supported")
+	} else {
+		require.NotEmpty(t, errors, "Errors should be returned when the WAF is not supported")
+	}
+
+	for _, err := range errors {
+		switch err.(type) {
+		case UnsupportedOSArchError:
+			require.Contains(t, *wafBuildTags, err.(UnsupportedOSArchError).Os, "The OS is marked as supported but a support error appeared", err)
+			require.Contains(t, *wafBuildTags, err.(UnsupportedOSArchError).Arch, "The architecture is marked as supported but a support error appeared", err)
+		case UnsupportedGoVersionError:
+			// We can't check anything here because we forced the version to be wrong we a build tag added manually instead of just having an incompatible version
+		case ManuallyDisabledError:
+			require.Contains(t, *wafBuildTags, "datadog.no_waf", "The WAF is marked as enabled but a support error appeared", err)
+		case CgoDisabledError:
+			require.NotContainsf(t, *wafBuildTags, "cgo", "The build tags contains cgo but a support error appeared", err)
+		default:
+			require.Fail(t, "Unknown error type", err)
+		}
+	}
+}

--- a/waf_unsupported_go.go
+++ b/waf_unsupported_go.go
@@ -8,6 +8,8 @@
 
 package waf
 
+import "runtime"
+
 func init() {
-	wafSupportErrors = append(wafSupportErrors, UnsupportedGoVersionError{})
+	wafSupportErrors = append(wafSupportErrors, UnsupportedGoVersionError{runtime.Version()})
 }

--- a/waf_unsupported_go_test.go
+++ b/waf_unsupported_go_test.go
@@ -8,6 +8,7 @@
 package waf_test
 
 import (
+	"runtime"
 	"testing"
 
 	waf "github.com/DataDog/go-libddwaf/v2"
@@ -19,7 +20,7 @@ func TestUnsupportedGoRuntime(t *testing.T) {
 		supported, err := waf.SupportsTarget()
 		require.False(t, supported)
 		require.Error(t, err)
-		require.ErrorIs(t, err, waf.UnsupportedGoVersionError{})
+		require.ErrorIs(t, err, waf.UnsupportedGoVersionError{runtime.Version()})
 	})
 
 	t.Run("TestLoad", func(t *testing.T) {


### PR DESCRIPTION
- [x] Run part of the previous job matrix as a script shell.
- [x] Switch go 1.22rc2 in favor of 1.22
- [x] Overall bump all timeout values for less flakyness 
- [x] Added missing build tags on handle_test.go
- [x] remove gotestsum 

Pros:
* Decreased CI time: p50 ~ 30min -> 3min | p95 ~ 2h -> 10m
* More understandable
* Does not hit the github job limit if we need to add another OS or Arch
* Less arm64 jobs = overall less flakyness

Cons:
* shell
* Alpine packages and Windows makes the shell a little tricky
* We are still dependent on arm64 job length