### PR TITLE
fix: unqualified use of constants moved

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,10 +34,10 @@ jobs:
     if: '!cancelled()'
     steps:
       - name: Done
-        if: success()
+        if: needs.bare-metal.result == 'success' && needs.containerized.result == 'success' && needs.smoke-tests.result == 'success'
         run: echo "Done!"
       - name: Done
-        if: failure()
+        if: needs.bare-metal.result != 'success' || needs.containerized.result != 'success' || needs.smoke-tests.result != 'success'
         run: |-
           echo "Failed!"
           exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,13 @@ jobs:
       - bare-metal
       - containerized
       - smoke-tests
+    if: '!cancelled()'
     steps:
       - name: Done
+        if: success()
         run: echo "Done!"
+      - name: Done
+        if: failure()
+        run: |-
+          echo "Failed!"
+          exit 1

--- a/waf_test.go
+++ b/waf_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/DataDog/go-libddwaf/v2/errors"
 
+	"github.com/DataDog/go-libddwaf/v2/internal/bindings"
 	"github.com/DataDog/go-libddwaf/v2/internal/lib"
 	"github.com/stretchr/testify/require"
 )
@@ -1120,21 +1121,21 @@ func TestTruncationInformation(t *testing.T) {
 	res, err := ctx.Run(RunAddressData{
 		Ephemeral: map[string]any{
 			"my.input": map[string]any{
-				"string_too_long":     strings.Repeat("Z", wafMaxStringLength+extra),
-				"container_too_large": make([]bool, wafMaxContainerSize+extra),
+				"string_too_long":     strings.Repeat("Z", bindings.WafMaxStringLength+extra),
+				"container_too_large": make([]bool, bindings.WafMaxContainerSize+extra),
 			},
 		},
 		Persistent: map[string]any{
 			"my.input.2": map[string]any{
-				"string_too_long":     strings.Repeat("Z", wafMaxStringLength+extra+2),
-				"container_too_large": make([]bool, wafMaxContainerSize+extra+2),
+				"string_too_long":     strings.Repeat("Z", bindings.WafMaxStringLength+extra+2),
+				"container_too_large": make([]bool, bindings.WafMaxContainerSize+extra+2),
 			},
 		},
 	}, time.Second)
 	require.NoError(t, err)
 	require.Equal(t, map[TruncationReason][]int{
-		StringTooLong:     {wafMaxStringLength + extra + 2, wafMaxStringLength + extra},
-		ContainerTooLarge: {wafMaxContainerSize + extra + 2, wafMaxContainerSize + extra},
+		StringTooLong:     {bindings.WafMaxStringLength + extra + 2, bindings.WafMaxStringLength + extra},
+		ContainerTooLarge: {bindings.WafMaxContainerSize + extra + 2, bindings.WafMaxContainerSize + extra},
 	}, res.Truncations)
 }
 


### PR DESCRIPTION
#73 inadvertently merged while attempting to use constants that were moved by #69. Somehow GitHub branch protection failed us (I'll make sure this PR considers that check as required).