### PR TITLE
feat: context-wide timeout

### DIFF
--- a/context.go
+++ b/context.go
@@ -6,6 +6,8 @@
 package waf
 
 import (
+	stdErrors "errors"
+	"github.com/DataDog/go-libddwaf/v2/timer"
 	"sync"
 	"time"
 
@@ -25,13 +27,16 @@ type Context struct {
 	cgoRefs  cgoRefPool          // Used to retain go data referenced by WAF Objects the context holds
 	cContext bindings.WafContext // The C ddwaf_context pointer
 
-	// Stats
-	totalRuntimeNs        atomic.Uint64 // Cumulative internal WAF run time - in nanoseconds - for this context.
-	totalOverallRuntimeNs atomic.Uint64 // Cumulative overall run time - in nanoseconds - for this context.
-	timeoutCount          atomic.Uint64 // Cumulative timeout count for this context.
+	timeoutCount atomic.Uint64 // Cumulative timeout count for this context.
 
 	// Mutex protecting the use of cContext which is not thread-safe and cgoRefs.
 	mutex sync.Mutex
+
+	// timer registers the time spent in the WAF and go-libddwaf
+	timer timer.NodeTimer
+
+	// stats stores the cumulative time spent in various parts of the WAF
+	stats metrics
 }
 
 // NewContext returns a new WAF context of to the given WAF handle.
@@ -40,6 +45,15 @@ type Context struct {
 // handle. A nil value is returned when the WAF handle can no longer be used
 // or the WAF context couldn't be created.
 func NewContext(handle *Handle) *Context {
+	return NewContextWithBudget(handle, timer.UnlimitedBudget)
+}
+
+// NewContextWithBudget returns a new WAF context of to the given WAF handle.
+// A nil value is returned when the WAF handle was released or when the
+// WAF context couldn't be created.
+// handle. A nil value is returned when the WAF handle can no longer be used
+// or the WAF context couldn't be created.
+func NewContextWithBudget(handle *Handle, budget time.Duration) *Context {
 	// Handle has been released
 	if !handle.retain() {
 		return nil
@@ -51,7 +65,12 @@ func NewContext(handle *Handle) *Context {
 		return nil
 	}
 
-	return &Context{handle: handle, cContext: cContext}
+	timer, err := timer.NewTreeTimer(timer.WithBudget(budget), timer.WithComponents("dd.appsec.waf.run"))
+	if err != nil {
+		return nil
+	}
+
+	return &Context{handle: handle, cContext: cContext, timer: timer, stats: metrics{data: make(map[string]time.Duration, 6)}}
 }
 
 // RunAddressData provides address data to the Context.Run method. If a given key is present in both
@@ -75,45 +94,74 @@ func (d RunAddressData) isEmpty() bool {
 // matches and actions can still be returned, for instance in the case of a timeout error. Errors can be tested against
 // the RunError type.
 // Struct fields having the tag `ddwaf:"ignore"` will not be encoded and sent to the WAF
-func (context *Context) Run(addressData RunAddressData, timeout time.Duration) (res Result, err error) {
+// if the output of TotalTime() exceeds the value of Timeout, the function will immediately return with an error
+func (context *Context) Run(addressData RunAddressData, budget time.Duration) (res Result, err error) {
 	if addressData.isEmpty() {
 		return
 	}
 
-	now := time.Now()
 	defer func() {
-		dt := time.Since(now)
-		context.totalOverallRuntimeNs.Add(uint64(dt.Nanoseconds()))
+		if stdErrors.Is(err, errors.ErrTimeout) {
+			context.timeoutCount.Inc()
+		}
 	}()
 
-	// At this point, the only error we can get is an error in case the top level object is a nil map, but this
-	// behaviour is expected since either persistent or ephemeral addresses are allowed to be null one at a time.
-	// In this case, EncodeAddresses will return nil contrary to Encode which will return an nil wafObject,
-	// which is what we need to send to ddwaf_run to signal that the address data is empty.
-	var persistentData *bindings.WafObject = nil
-	var ephemeralData *bindings.WafObject = nil
-	persistentEncoder := newLimitedEncoder()
-	ephemeralEncoder := newLimitedEncoder()
-	if addressData.Persistent != nil {
-		persistentData, _ = persistentEncoder.EncodeAddresses(addressData.Persistent)
+	// If the context has already timed out, we don't need to run the WAF again
+	if context.timer.SumExhausted() {
+		return Result{}, errors.ErrTimeout
 	}
 
-	if addressData.Ephemeral != nil {
-		ephemeralData, _ = ephemeralEncoder.EncodeAddresses(addressData.Ephemeral)
-
+	runTimer, err := context.timer.NewNode("dd.appsec.waf.run", timer.WithBudget(budget),
+		timer.WithComponents(
+			"dd.appsec.waf.encode.persistent",
+			"dd.appsec.waf.encode.ephemeral",
+			"dd.appsec.waf.lock",
+			"dd.appsec.waf.duration_ext",
+			"dd.appsec.waf.duration",
+		),
+	)
+	if err != nil {
+		return Result{}, err
 	}
-	// The WAF releases ephemeral address data at the end of each run call, so we need not keep the Go values live beyond
+
+	runTimer.Start()
+	defer func() {
+		context.stats.add("dd.appsec.waf.run", runTimer.Stop())
+		context.stats.append(runTimer.Stats())
+	}()
+
+	persistentData, persistentEncoder, err := context.encodeOneAddressType(addressData.Persistent, runTimer.MustLeaf("dd.appsec.waf.encode.persistent"))
+	if err != nil {
+		return res, err
+	}
+
+	// The WAF releases ephemeral address data at the max of each run call, so we need not keep the Go values live beyond
 	// that in the same way we need for persistent data. We hence use a separate encoder.
+	ephemeralData, ephemeralEncoder, err := context.encodeOneAddressType(addressData.Ephemeral, runTimer.MustLeaf("dd.appsec.waf.encode.persistent"))
+	if err != nil {
+		return res, err
+	}
 
 	// ddwaf_run cannot run concurrently and the next append write on the context state so we need a mutex
+	waitTimer := runTimer.MustLeaf("dd.appsec.waf.lock")
+	waitTimer.Start()
 	context.mutex.Lock()
+	waitTimer.Stop()
+
 	defer context.mutex.Unlock()
+
+	if runTimer.SumExhausted() {
+		return res, errors.ErrTimeout
+	}
 
 	// Save the Go pointer references to addressesToData that were referenced by the encoder
 	// into C ddwaf_objects. libddwaf's API requires to keep this data for the lifetime of the ddwaf_context.
 	defer context.cgoRefs.append(persistentEncoder.cgoRefs)
 
-	res, err = context.run(persistentData, ephemeralData, timeout)
+	wafExtTimer := runTimer.MustLeaf("dd.appsec.waf.duration_ext")
+	res, err = context.run(persistentData, ephemeralData, wafExtTimer, runTimer.SumRemaining())
+
+	runTimer.AddTime("dd.appsec.waf.duration", res.TimeSpent)
 
 	// Ensure the ephemerals don't get optimized away by the compiler before the WAF had a chance to use them.
 	unsafe.KeepAlive(ephemeralEncoder.cgoRefs)
@@ -157,21 +205,38 @@ func merge[K comparable, V any](a, b map[K][]V) (merged map[K][]V) {
 	return
 }
 
+// encodeOneAddressType encodes the given addressData values and returns the corresponding WAF object and its refs.
+// If the addressData is empty, it returns nil for the WAF object and an empty ref pool.
+// At this point, the only error we can get is an error in case the top level object is a nil map, but this
+// behaviour is expected since either persistent or ephemeral addresses are allowed to be null one at a time.
+// In this case, EncodeAddresses will return nil contrary to Encode which will return an nil wafObject,
+// which is what we need to send to ddwaf_run to signal that the address data is empty.
+func (context *Context) encodeOneAddressType(addressData map[string]any, timer timer.Timer) (*bindings.WafObject, encoder, error) {
+	encoder := newLimitedEncoder(timer)
+	if addressData == nil {
+		return nil, encoder, nil
+	}
+
+	data, _ := encoder.EncodeAddresses(addressData)
+
+	if timer.Exhausted() {
+		return nil, encoder, errors.ErrTimeout
+	}
+
+	return data, encoder, nil
+}
+
 // run executes the ddwaf_run call with the provided data on this context. The caller is responsible for locking the
 // context appropriately around this call.
-func (context *Context) run(persistentData, ephemeralData *bindings.WafObject, timeout time.Duration) (Result, error) {
+func (context *Context) run(persistentData, ephemeralData *bindings.WafObject, timer timer.Timer, timeBudget time.Duration) (Result, error) {
 	result := new(bindings.WafResult)
 	defer wafLib.WafResultFree(result)
 
-	ret := wafLib.WafRun(context.cContext, persistentData, ephemeralData, result, uint64(timeout/time.Microsecond))
+	timer.Start()
+	defer timer.Stop()
+	ret := wafLib.WafRun(context.cContext, persistentData, ephemeralData, result, uint64(timeBudget.Microseconds()))
 
-	context.totalRuntimeNs.Add(result.TotalRuntime)
-	res, err := unwrapWafResult(ret, result)
-	if err == errors.ErrTimeout {
-		context.timeoutCount.Inc()
-	}
-
-	return res, err
+	return unwrapWafResult(ret, result)
 }
 
 func unwrapWafResult(ret bindings.WafReturnCode, result *bindings.WafResult) (res Result, err error) {
@@ -204,6 +269,7 @@ func unwrapWafResult(ret bindings.WafReturnCode, result *bindings.WafResult) (re
 		}
 	}
 
+	res.TimeSpent = time.Duration(result.TotalRuntime)
 	return res, err
 }
 
@@ -216,7 +282,7 @@ func (context *Context) Close() {
 	defer context.mutex.Unlock()
 
 	wafLib.WafContextDestroy(context.cContext)
-	unsafe.KeepAlive(context.cgoRefs) // Keep the Go pointer references until the end of the context
+	unsafe.KeepAlive(context.cgoRefs) // Keep the Go pointer references until the max of the context
 	defer context.handle.release()    // Reduce the reference counter of the Handle.
 
 	context.cgoRefs = cgoRefPool{} // The data in context.cgoRefs is no longer needed, explicitly release
@@ -225,11 +291,61 @@ func (context *Context) Close() {
 
 // TotalRuntime returns the cumulated WAF runtime across various run calls within the same WAF context.
 // Returned time is in nanoseconds.
-func (context *Context) TotalRuntime() (overallRuntimeNs, internalRuntimeNs uint64) {
-	return context.totalOverallRuntimeNs.Load(), context.totalRuntimeNs.Load()
+// Deprecated: use Timings instead
+func (context *Context) TotalRuntime() (uint64, uint64) {
+	return uint64(context.stats.get("dd.appsec.waf.run") * time.Nanosecond), uint64(context.stats.get("dd.appsec.waf.duration"))
 }
 
 // TotalTimeouts returns the cumulated amount of WAF timeouts across various run calls within the same WAF context.
+// Deprecated: use Timings instead
 func (context *Context) TotalTimeouts() uint64 {
 	return context.timeoutCount.Load()
+}
+
+// Stats returns the cumulative time spent in various parts of the WAF, all in nanoseconds
+// and the timeout value used
+func (context *Context) Stats() map[string]time.Duration {
+	return context.stats.copy()
+}
+
+type metrics struct {
+	data  map[string]time.Duration
+	mutex sync.RWMutex
+}
+
+// add
+func (metrics *metrics) add(key string, duration time.Duration) {
+	metrics.mutex.Lock()
+	defer metrics.mutex.Unlock()
+	metrics.data[key] += duration
+}
+
+// get
+func (metrics *metrics) get(key string) time.Duration {
+	metrics.mutex.RLock()
+	defer metrics.mutex.RUnlock()
+	return metrics.data[key]
+}
+
+func (metrics *metrics) copy() map[string]time.Duration {
+	metrics.mutex.Lock()
+	defer metrics.mutex.Unlock()
+	copy := make(map[string]time.Duration, len(metrics.data))
+	for k, v := range metrics.data {
+		copy[k] = v
+	}
+	return copy
+}
+
+// append merges the current metrics with the new run
+func (metrics *metrics) append(other map[string]time.Duration) {
+	metrics.mutex.Lock()
+	defer metrics.mutex.Unlock()
+	for key, val := range other {
+		prev, ok := metrics.data[key]
+		if !ok {
+			prev = 0
+		}
+		metrics.data[key] = prev + val
+	}
 }

--- a/context.go
+++ b/context.go
@@ -94,7 +94,7 @@ func (d RunAddressData) isEmpty() bool {
 // the RunError type.
 // Struct fields having the tag `ddwaf:"ignore"` will not be encoded and sent to the WAF
 // if the output of TotalTime() exceeds the value of Timeout, the function will immediately return with errors.ErrTimeout
-func (context *Context) Run(addressData RunAddressData, budget time.Duration) (res Result, err error) {
+func (context *Context) Run(addressData RunAddressData, _ time.Duration) (res Result, err error) {
 	if addressData.isEmpty() {
 		return
 	}
@@ -110,7 +110,7 @@ func (context *Context) Run(addressData RunAddressData, budget time.Duration) (r
 		return Result{}, errors.ErrTimeout
 	}
 
-	runTimer, err := context.timer.NewNode("dd.appsec.waf.run", timer.WithBudget(budget),
+	runTimer, err := context.timer.NewNode("dd.appsec.waf.run",
 		timer.WithComponents(
 			"dd.appsec.waf.encode.persistent",
 			"dd.appsec.waf.encode.ephemeral",

--- a/context.go
+++ b/context.go
@@ -114,7 +114,6 @@ func (context *Context) Run(addressData RunAddressData, _ time.Duration) (res Re
 		timer.WithComponents(
 			"dd.appsec.waf.encode.persistent",
 			"dd.appsec.waf.encode.ephemeral",
-			"dd.appsec.waf.lock",
 			"dd.appsec.waf.duration_ext",
 			"dd.appsec.waf.duration",
 		),
@@ -142,11 +141,7 @@ func (context *Context) Run(addressData RunAddressData, _ time.Duration) (res Re
 	}
 
 	// ddwaf_run cannot run concurrently and the next merge write on the context state so we need a mutex
-	waitTimer := runTimer.MustLeaf("dd.appsec.waf.lock")
-	waitTimer.Start()
 	context.mutex.Lock()
-	waitTimer.Stop()
-
 	defer context.mutex.Unlock()
 
 	if runTimer.SumExhausted() {

--- a/encoder_decoder_test.go
+++ b/encoder_decoder_test.go
@@ -10,6 +10,7 @@ package waf
 import (
 	"context"
 	"encoding/json"
+	"github.com/DataDog/go-libddwaf/v2/timer"
 	"reflect"
 	"sort"
 	"testing"
@@ -530,7 +531,9 @@ func TestEncoderLimits(t *testing.T) {
 		if max := tc.MaxStringLength; max != nil {
 			maxStringLength = max.(int)
 		}
+		encodeTimer, _ := timer.NewTimer(timer.WithUnlimitedBudget())
 		encoder := encoder{
+			timer:            encodeTimer,
 			objectMaxDepth:   maxValueDepth,
 			stringMaxSize:    maxStringLength,
 			containerMaxSize: maxContainerLength,

--- a/timer/node_timer.go
+++ b/timer/node_timer.go
@@ -99,6 +99,15 @@ func (timer *nodeTimer) childStopped(componentName string, duration time.Duratio
 	timer.parent.childStopped(timer.componentName, duration)
 }
 
+func (timer *nodeTimer) AddTime(name string, duration time.Duration) {
+	value, ok := timer.components.lookup[name]
+	if !ok {
+		return
+	}
+
+	value.Add(int64(duration))
+}
+
 func (timer *nodeTimer) Stats() map[string]time.Duration {
 	stats := make(map[string]time.Duration, len(timer.components.lookup))
 	for name, component := range timer.components.lookup {

--- a/timer/timer.go
+++ b/timer/timer.go
@@ -96,6 +96,10 @@ type NodeTimer interface {
 	// MustLeaf is thread-safe
 	MustLeaf(name string, options ...Option) Timer
 
+	// AddTime adds the given duration to the component of the timer with the given name.
+	// AddTime is thread-safe
+	AddTime(name string, duration time.Duration)
+
 	// Stats returns a map of the time spent in each component of the timer.
 	// Stats is thread-safe
 	Stats() map[string]time.Duration

--- a/waf.go
+++ b/waf.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	wafErrors "github.com/DataDog/go-libddwaf/v2/errors"
 	"sync"
+	"time"
 
 	"github.com/DataDog/go-libddwaf/v2/internal/bindings"
 	"github.com/DataDog/go-libddwaf/v2/internal/support"
@@ -95,6 +96,9 @@ type Result struct {
 	// Truncatations provides details about truncations that occurred while
 	// encoding address data for WAF execution.
 	Truncations map[TruncationReason][]int
+
+	// TimeSpent is the time the WAF self-reported as spent processing the call to ddwaf_run
+	TimeSpent time.Duration
 }
 
 // Globally dlopen() libddwaf only once because several dlopens (eg. in tests)

--- a/waf_test.go
+++ b/waf_test.go
@@ -234,12 +234,6 @@ func newDefaultHandle(rule any) (*Handle, error) {
 	return NewHandle(rule, "", "")
 }
 
-func newTestContext(t *testing.T, waf *Handle) *Context {
-	wafCtx := NewContext(waf)
-	require.NotNil(t, wafCtx)
-	return wafCtx
-}
-
 func TestNewWAF(t *testing.T) {
 	t.Run("valid-rule", func(t *testing.T) {
 		waf, err := newDefaultHandle(testArachniRule)
@@ -279,7 +273,7 @@ func TestUpdateWAF(t *testing.T) {
 		require.NotNil(t, waf)
 		defer waf.Close()
 
-		wafCtx := newTestContext(t, waf)
+		wafCtx := NewContext(waf)
 		defer wafCtx.Close()
 
 		// Matches
@@ -300,7 +294,7 @@ func TestUpdateWAF(t *testing.T) {
 		require.NotNil(t, waf2)
 		defer waf2.Close()
 
-		wafCtx2 := newTestContext(t, waf2)
+		wafCtx2 := NewContext(waf2)
 		defer wafCtx2.Close()
 
 		// Matches & Block
@@ -339,7 +333,7 @@ func TestMatching(t *testing.T) {
 
 	require.Equal(t, []string{"my.input"}, waf.Addresses())
 
-	wafCtx := newTestContext(t, waf)
+	wafCtx := NewContext(waf)
 	require.NotNil(t, wafCtx)
 
 	// Not matching because the address value doesn't match the rule
@@ -412,7 +406,7 @@ func TestMatchingEphemeralAndPersistent(t *testing.T) {
 	require.NoError(t, err)
 	defer waf.Close()
 
-	wafCtx := newTestContext(t, waf)
+	wafCtx := NewContext(waf)
 	require.NotNil(t, wafCtx)
 	defer wafCtx.Close()
 
@@ -464,7 +458,7 @@ func TestMatchingEphemeral(t *testing.T) {
 	sort.Strings(addrs)
 	require.Equal(t, []string{input1, input2}, addrs)
 
-	wafCtx := newTestContext(t, waf)
+	wafCtx := NewContext(waf)
 	require.NotNil(t, wafCtx)
 
 	// Not matching because the address value doesn't match the rule
@@ -542,7 +536,7 @@ func TestMatchingEphemeralOnly(t *testing.T) {
 	sort.Strings(addrs)
 	require.Equal(t, []string{input1, input2}, addrs)
 
-	wafCtx := newTestContext(t, waf)
+	wafCtx := NewContext(waf)
 	require.NotNil(t, wafCtx)
 
 	// Not matching because the address value doesn't match the rule
@@ -600,7 +594,7 @@ func TestActions(t *testing.T) {
 			require.NotNil(t, waf)
 			defer waf.Close()
 
-			wafCtx := newTestContext(t, waf)
+			wafCtx := NewContext(waf)
 			require.NotNil(t, wafCtx)
 			defer wafCtx.Close()
 
@@ -642,7 +636,7 @@ func TestConcurrency(t *testing.T) {
 		require.NoError(t, err)
 		defer waf.Close()
 
-		wafCtx := newTestContext(t, waf)
+		wafCtx := NewContext(waf)
 		defer wafCtx.Close()
 
 		// User agents that won't match the rule so that it doesn't get pruned.
@@ -736,7 +730,7 @@ func TestConcurrency(t *testing.T) {
 				startBarrier.Wait()      // Sync the starts of the goroutines
 				defer stopBarrier.Done() // Signal we are done when returning
 
-				wafCtx := newTestContext(t, waf)
+				wafCtx := NewContext(waf)
 				defer wafCtx.Close()
 
 				for c := 0; c < nbRun; c++ {
@@ -805,7 +799,7 @@ func TestConcurrency(t *testing.T) {
 				startBarrier.Wait()      // Sync the starts of the goroutines
 				defer stopBarrier.Done() // Signal we are done when returning
 
-				wafCtx := newTestContext(t, waf)
+				wafCtx := NewContext(waf)
 				if wafCtx == nil {
 					return
 				}
@@ -838,7 +832,7 @@ func TestConcurrency(t *testing.T) {
 		waf, err := newDefaultHandle(testArachniRule)
 		require.NoError(t, err)
 
-		wafCtx := newTestContext(t, waf)
+		wafCtx := NewContext(waf)
 		require.NotNil(t, wafCtx)
 
 		var startBarrier, stopBarrier sync.WaitGroup
@@ -1002,7 +996,7 @@ func TestMetrics(t *testing.T) {
 	})
 
 	t.Run("RunDuration", func(t *testing.T) {
-		wafCtx := newTestContext(t, waf)
+		wafCtx := NewContext(waf)
 		require.NotNil(t, wafCtx)
 		defer wafCtx.Close()
 		// Craft matching data to force work on the WAF
@@ -1053,7 +1047,7 @@ func TestObfuscatorConfig(t *testing.T) {
 		waf, err := NewHandle(rule, "key", "")
 		require.NoError(t, err)
 		defer waf.Close()
-		wafCtx := newTestContext(t, waf)
+		wafCtx := NewContext(waf)
 		require.NotNil(t, wafCtx)
 		defer wafCtx.Close()
 		data := map[string]interface{}{
@@ -1075,7 +1069,7 @@ func TestObfuscatorConfig(t *testing.T) {
 		waf, err := NewHandle(rule, "", "sensitive")
 		require.NoError(t, err)
 		defer waf.Close()
-		wafCtx := newTestContext(t, waf)
+		wafCtx := NewContext(waf)
 		require.NotNil(t, wafCtx)
 		defer wafCtx.Close()
 		data := map[string]interface{}{
@@ -1097,7 +1091,7 @@ func TestObfuscatorConfig(t *testing.T) {
 		waf, err := NewHandle(rule, "", "")
 		require.NoError(t, err)
 		defer waf.Close()
-		wafCtx := newTestContext(t, waf)
+		wafCtx := NewContext(waf)
 		require.NotNil(t, wafCtx)
 		defer wafCtx.Close()
 		data := map[string]interface{}{

--- a/waf_test.go
+++ b/waf_test.go
@@ -368,7 +368,7 @@ func TestTimeout(t *testing.T) {
 		"my.input": "Arachni",
 	}
 
-	t.Run("not-empty-stats", func(t *testing.T) {
+	t.Run("not-empty-metricsStore", func(t *testing.T) {
 		context := NewContextWithBudget(waf, time.Millisecond)
 		require.NotNil(t, context)
 		defer context.Close()
@@ -376,11 +376,11 @@ func TestTimeout(t *testing.T) {
 		_, err := context.Run(RunAddressData{Persistent: normalValue, Ephemeral: normalValue}, 0)
 		require.NoError(t, err)
 		require.NotEmpty(t, context.Stats())
-		require.NotZero(t, context.Stats()["dd.appsec.waf.run"])
-		require.NotZero(t, context.Stats()["dd.appsec.waf.encode.persistent"])
-		require.NotZero(t, context.Stats()["dd.appsec.waf.encode.ephemeral"])
-		require.NotZero(t, context.Stats()["dd.appsec.waf.duration_ext"])
-		require.NotZero(t, context.Stats()["dd.appsec.waf.duration"])
+		require.NotZero(t, context.Stats()["_dd.appsec.waf.run"])
+		require.NotZero(t, context.Stats()["_dd.appsec.waf.encode.persistent"])
+		require.NotZero(t, context.Stats()["_dd.appsec.waf.encode.ephemeral"])
+		require.NotZero(t, context.Stats()["_dd.appsec.waf.duration_ext"])
+		require.NotZero(t, context.Stats()["_dd.appsec.waf.duration"])
 	})
 
 	t.Run("timeout-persistent-encoder", func(t *testing.T) {
@@ -390,9 +390,9 @@ func TestTimeout(t *testing.T) {
 
 		_, err := context.Run(RunAddressData{Persistent: largeValue}, 0)
 		require.Equal(t, errors.ErrTimeout, err)
-		require.GreaterOrEqual(t, context.Stats()["dd.appsec.waf.run"], time.Millisecond)
-		require.GreaterOrEqual(t, context.Stats()["dd.appsec.waf.encode.persistent"], time.Millisecond)
-		require.Equal(t, context.Stats()["dd.appsec.waf.encode.ephemeral"], time.Duration(0))
+		require.GreaterOrEqual(t, context.Stats()["_dd.appsec.waf.run"], time.Millisecond)
+		require.GreaterOrEqual(t, context.Stats()["_dd.appsec.waf.encode.persistent"], time.Millisecond)
+		require.Equal(t, context.Stats()["_dd.appsec.waf.encode.ephemeral"], time.Duration(0))
 	})
 
 	t.Run("timeout-ephemeral-encoder", func(t *testing.T) {
@@ -402,9 +402,9 @@ func TestTimeout(t *testing.T) {
 
 		_, err := context.Run(RunAddressData{Ephemeral: largeValue}, 0)
 		require.Equal(t, errors.ErrTimeout, err)
-		require.GreaterOrEqual(t, context.Stats()["dd.appsec.waf.run"], time.Millisecond)
-		require.Equal(t, context.Stats()["dd.appsec.waf.encode.persistent"], time.Duration(0))
-		require.GreaterOrEqual(t, context.Stats()["dd.appsec.waf.encode.ephemeral"], time.Millisecond)
+		require.GreaterOrEqual(t, context.Stats()["_dd.appsec.waf.run"], time.Millisecond)
+		require.Equal(t, context.Stats()["_dd.appsec.waf.encode.persistent"], time.Duration(0))
+		require.GreaterOrEqual(t, context.Stats()["_dd.appsec.waf.encode.ephemeral"], time.Millisecond)
 	})
 
 	t.Run("many-runs", func(t *testing.T) {
@@ -762,7 +762,7 @@ func TestConcurrency(t *testing.T) {
 			}()
 		}
 
-		// Save the test start time to compare it to the first metrics store's
+		// Save the test start time to compare it to the first metricsStore store's
 		// that should be latter.
 		startBarrier.Done() // Unblock the user goroutines
 		stopBarrier.Wait()  // Wait for the user goroutines to be done
@@ -847,7 +847,7 @@ func TestConcurrency(t *testing.T) {
 			}()
 		}
 
-		// Save the test start time to compare it to the first metrics store's
+		// Save the test start time to compare it to the first metricsStore store's
 		// that should be latter.
 		startBarrier.Done() // Unblock the user goroutines
 		stopBarrier.Wait()  // Wait for the user goroutines to be done
@@ -894,7 +894,7 @@ func TestConcurrency(t *testing.T) {
 			waf.Close()
 		}()
 
-		// Save the test start time to compare it to the first metrics store's
+		// Save the test start time to compare it to the first metricsStore store's
 		// that should be latter.
 		startBarrier.Done() // Unblock the user goroutines
 		stopBarrier.Wait()  // Wait for the user goroutines to be done


### PR DESCRIPTION
## Tasks

- [x] Add function `NewContextWithBudget`
- [x] Add new context method `Stats()` to get all time-related stats provided by go-libddwaf
- [x] The timeout value supplied in `Run()` is now a noop. 
- [x] Use the `timer` package 
- [x] The remaining time after the encoder is passed as value to ddwaf_run
- [x] The depth measuring will now happen only happen if there is still enough time to do it

## Reviewers

Please look at the Run function using the side-by-side view and not the inline diff view