### PR TITLE
chore: test ARM64 on bare metal

### DIFF
--- a/.github/workflows/_test_bare_metal.yml
+++ b/.github/workflows/_test_bare_metal.yml
@@ -24,7 +24,7 @@ jobs:
       # ARM runners (at least during early access) don't have GCC installed
       - if: matrix.runs-on == 'arm-4core-linux'
         name: Install build requirements (ARM only)
-        run: apt update && apt-install -y gcc
+        run: sudo apt update && sudo apt-install -y gcc
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
       - name: go test

--- a/.github/workflows/_test_bare_metal.yml
+++ b/.github/workflows/_test_bare_metal.yml
@@ -7,8 +7,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ macos-14, macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04, windows-latest ]
-        go-version: [ "1.22", "1.21", "1.20", "1.19" ]
+        runs-on: [ macos-14, macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04, windows-latest, arm-4core-linux ]
+        go-version: [ '1.22', '1.21', '1.20' ]
         include:
           # Test with DD_APPSEC_WAF_LOG_LEVEL (only latest go version)
           - go-version: '1.22'

--- a/.github/workflows/_test_bare_metal.yml
+++ b/.github/workflows/_test_bare_metal.yml
@@ -24,7 +24,7 @@ jobs:
       # ARM runners (at least during early access) don't have GCC installed
       - if: matrix.runs-on == 'arm-4core-linux'
         name: Install build requirements (ARM only)
-        run: sudo apt update && sudo apt install -y build-essentials
+        run: sudo apt update && sudo apt install -y build-essential
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
       - name: go test

--- a/.github/workflows/_test_bare_metal.yml
+++ b/.github/workflows/_test_bare_metal.yml
@@ -24,7 +24,7 @@ jobs:
       # ARM runners (at least during early access) don't have GCC installed
       - if: matrix.runs-on == 'arm-4core-linux'
         name: Install build requirements (ARM only)
-        run: sudo apt update && sudo apt-install -y gcc
+        run: sudo apt update && sudo apt install -y build-essentials
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
       - name: go test

--- a/.github/workflows/_test_bare_metal.yml
+++ b/.github/workflows/_test_bare_metal.yml
@@ -21,6 +21,10 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
           cache: true
+      # ARM runners (at least during early access) don't have GCC installed
+      - if: matrix.runs-on == 'arm-4core-linux'
+        name: Install build requirements (ARM only)
+        run: apt update && apt-install -y gcc
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
       - name: go test

--- a/.github/workflows/_test_containerized.yml
+++ b/.github/workflows/_test_containerized.yml
@@ -15,18 +15,12 @@ jobs:
           - golang:{0}-buster
           # RPM-based image
           - amazonlinux:2 # pretty popular on AWS workloads
-        arch: [ amd64, arm64 ]
         go-version: [ "1.22", "1.21", "1.20", "1.19" ]
         include:
           # Test with DD_APPSEC_WAF_LOG_LEVEL (only latest go, without any particular tag)
           - go-version: '1.22'
             waf-log-level: TRACE
         exclude:
-          # Test arm64 on a subset of the matrix for now to make it quicker to run due to qemu
-          - arch: arm64
-            image: golang:{0}-buster
-          - arch: arm64
-            image: golang:{0}-bullseye
           # Prune inexistent build images (debian buster is on LTS but won't get new go version images)
           - go-version: '1.21'
             image: golang:{0}-buster
@@ -49,16 +43,10 @@ jobs:
           path: ~/go/pkg/mod
           key: go-pkg-mod-${{ hashFiles('**/go.sum') }}
           restore-keys: go-pkg-mod-
-      - name: Set up QEMU
-        if: matrix.arch == 'arm64'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
       - name: Create container
         id: container
         run: |-
           docker run --name gha-${{ github.run_id }} --rm -di                   \
-            --platform="linux/${{ matrix.arch }}"                               \
             -v "${HOME}/go/pkg/mod:/go/pkg/mod"                                 \
             -v "$PWD:$PWD"                                                      \
             -w "$PWD"                                                           \


### PR DESCRIPTION
Moves testing for ARM64 to new "bare-metal" runners, and stop running these on QEMU in Docker. This provides a significant performance enhancement for these cases.