### PR TITLE
chore: also run containerized tests on ARM

### DIFF
--- a/.github/workflows/_test_bare_metal.yml
+++ b/.github/workflows/_test_bare_metal.yml
@@ -13,7 +13,7 @@ jobs:
           # Test with DD_APPSEC_WAF_LOG_LEVEL (only latest go version)
           - go-version: '1.22'
             waf-log-level: TRACE
-    name: ${{ toJSON(matrix) }}
+    name: ${{ matrix.runs-on }} go${{ matrix.go-version }}${{ matrix.waf-log-level && format(' (DD_APPSEC_WAF_LOG_LEVEL={0})', matrix.waf-log-level) || '' }}
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/_test_containerized.yml
+++ b/.github/workflows/_test_containerized.yml
@@ -7,6 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        arch: [ amd64, arm64 ]
         image:
           # Standard golang images
           - golang:{0}-alpine
@@ -15,7 +16,7 @@ jobs:
           - golang:{0}-buster
           # RPM-based image
           - amazonlinux:2 # pretty popular on AWS workloads
-        go-version: [ "1.22", "1.21", "1.20", "1.19" ]
+        go-version: [ "1.22", "1.21", "1.20" ]
         include:
           # Test with DD_APPSEC_WAF_LOG_LEVEL (only latest go, without any particular tag)
           - go-version: '1.22'
@@ -28,15 +29,29 @@ jobs:
           - go-version: '1.22'
             image: golang:{0}-buster
           # The amazonlinux:2 variant is only relevant for the default go version yum ships (currently 1.20)
-          - go-version: '1.19'
-            image: amazonlinux:2
           - go-version: '1.21'
             image: amazonlinux:2
           - go-version: '1.22'
             image: amazonlinux:2
     name: ${{ toJSON(matrix) }}
-    runs-on: ubuntu-latest
+    # We use ARM runners when needed to avoid the performance hit of QEMU
+    runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-latest' || 'arm-4core-linux' }}
     steps:
+      # Docker is not present on early-access ARM runners
+      - name: Prepare ARM Runner
+        if: matrix.arch == 'arm64'
+        run: |-
+          for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do sudo apt-get remove -y $pkg || echo "Not present: $pkg"; done
+
+          sudo apt update
+          sudo apt install -y ca-certificates curl
+          sudo install -m 0755 -d /etc/apt/keyrings
+          sudo curl -fsSL "https://download.docker.com/linux/ubuntu/gpg" -o /etc/apt/keyrings/docker.asc
+          sudo chmod a+r /etc/apt/keyrings/docker.asc
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list
+          sudo apt update
+          sudo apt install -y docker-ce docker-ce-cli containerd.io
+
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
         with:
@@ -46,7 +61,7 @@ jobs:
       - name: Create container
         id: container
         run: |-
-          docker run --name gha-${{ github.run_id }} --rm -di                   \
+          sudo docker run --name gha-${{ github.run_id }} --rm -di              \
             -v "${HOME}/go/pkg/mod:/go/pkg/mod"                                 \
             -v "$PWD:$PWD"                                                      \
             -w "$PWD"                                                           \
@@ -56,12 +71,12 @@ jobs:
       - name: Install AmazonLinux 2 requirements
         if: matrix.image == 'amazonlinux:2'
         run: |-
-          docker exec -i gha-${{ github.run_id }}                               \
+          sudo docker exec -i gha-${{ github.run_id }}                          \
             yum install -y golang
       - name: Run the ci.sh script
         run: |-
-          docker exec -i gha-${{ github.run_id }} $PWD/.github/workflows/ci.sh
+          sudo docker exec -i gha-${{ github.run_id }} $PWD/.github/workflows/ci.sh
       - name: Stop container
         if: always() && steps.container.outcome == 'success'
         run: |-
-          docker stop gha-${{ github.run_id }}
+          sudo docker stop gha-${{ github.run_id }}

--- a/.github/workflows/_test_containerized.yml
+++ b/.github/workflows/_test_containerized.yml
@@ -33,7 +33,7 @@ jobs:
             image: amazonlinux:2
           - go-version: '1.22'
             image: amazonlinux:2
-    name: ${{ toJSON(matrix) }}
+    name: ${{ matrix.arch }} ${{ format(matrix.image, matrix.go-version) }} go${{ matrix.go-version }}${{ matrix.waf-log-level && format(' (DD_APPSEC_WAF_LOG_LEVEL={0})', matrix.waf-log-level) || '' }}
     # We use ARM runners when needed to avoid the performance hit of QEMU
     runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-latest' || 'arm-4core-linux' }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   bare-metal:
-    name: Directly on GitHub Runner
+    name: GitHub Runner
     uses: ./.github/workflows/_test_bare_metal.yml
   containerized:
     name: Containerized

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,13 @@ on:
 
 jobs:
   bare-metal:
+    name: Directly on GitHub Runner
     uses: ./.github/workflows/_test_bare_metal.yml
   containerized:
+    name: Containerized
     uses: ./.github/workflows/_test_containerized.yml
   smoke-tests:
+    name: Smoke Tests
     uses: DataDog/dd-trace-go/.github/workflows/smoke-tests.yml@main
     with:
       ref: main


### PR DESCRIPTION
Also removed 1.19 suite since the package's `go.mod` declares `go 1.20`...