### PR TITLE
fix: put back duration_ext metric as the top-level timer

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -106,8 +106,6 @@ func (encoder *encoder) Encode(data any) (wo *bindings.WafObject, err error) {
 	value := reflect.ValueOf(data)
 	wo = &bindings.WafObject{}
 
-	encoder.timer.Start()
-	defer encoder.timer.Stop()
 	err = encoder.encode(value, wo, encoder.objectMaxDepth)
 
 	if len(encoder.truncations[ObjectTooDeep]) != 0 && !encoder.timer.Exhausted() {
@@ -123,21 +121,6 @@ func (encoder *encoder) Truncations() map[TruncationReason][]int {
 	result := encoder.truncations
 	encoder.truncations = nil
 	return result
-}
-
-// EncodeAddresses takes a map of Go values and returns a wafObject pointer and an error.
-// The returned wafObject is the root of the tree of nested wafObjects representing the Go values.
-// This function is further optimized from Encode to take addresses as input and avoid further
-// errors in case the top-level map with addresses as keys is nil.
-// Since errors returned by Encode are not sent up between levels of the tree, this means that all errors come from the
-// top layer of encoding, which is the map of addresses. Hence, all errors should be developer errors since the map of
-// addresses is not user defined custom data.
-func (encoder *encoder) EncodeAddresses(addresses map[string]any) (*bindings.WafObject, error) {
-	if addresses == nil {
-		return nil, errors.ErrUnsupportedValue
-	}
-
-	return encoder.Encode(addresses)
 }
 
 func encodeNative[T native](val T, t bindings.WafObjectType, obj *bindings.WafObject) {

--- a/metrics.go
+++ b/metrics.go
@@ -27,9 +27,9 @@ type Stats struct {
 const (
 	wafPersistentEncoderTag = "_dd.appsec.waf.encode.persistent"
 	wafEphemeralEncoderTag  = "_dd.appsec.waf.encode.ephemeral"
-	wafRunTag               = "_dd.appsec.waf.run"
+	wafRunTag               = "_dd.appsec.waf.duration_ext"
 	wafDurationTag          = "_dd.appsec.waf.duration"
-	wafDurationExtTag       = "_dd.appsec.waf.duration_ext"
+	wafDecodeTag            = "_dd.appsec.waf.decode"
 	wafTimeoutTag           = "_dd.appsec.waf.timeouts"
 	wafTruncationTag        = "_dd.appsec.waf.truncations"
 )

--- a/metrics.go
+++ b/metrics.go
@@ -25,13 +25,12 @@ type Stats struct {
 }
 
 const (
-	wafPersistentEncoderTag = "_dd.appsec.waf.encode.persistent"
-	wafEphemeralEncoderTag  = "_dd.appsec.waf.encode.ephemeral"
-	wafRunTag               = "_dd.appsec.waf.duration_ext"
-	wafDurationTag          = "_dd.appsec.waf.duration"
-	wafDecodeTag            = "_dd.appsec.waf.decode"
-	wafTimeoutTag           = "_dd.appsec.waf.timeouts"
-	wafTruncationTag        = "_dd.appsec.waf.truncations"
+	wafEncodeTag     = "_dd.appsec.waf.encode"
+	wafRunTag        = "_dd.appsec.waf.duration_ext"
+	wafDurationTag   = "_dd.appsec.waf.duration"
+	wafDecodeTag     = "_dd.appsec.waf.decode"
+	wafTimeoutTag    = "_dd.appsec.waf.timeouts"
+	wafTruncationTag = "_dd.appsec.waf.truncations"
 )
 
 // Metrics transform the stats returned by the WAF into a map of key value metrics for datadog backend

--- a/waf_test.go
+++ b/waf_test.go
@@ -376,7 +376,7 @@ func TestTimeout(t *testing.T) {
 		_, err := context.Run(RunAddressData{Persistent: normalValue, Ephemeral: normalValue}, 0)
 		require.NoError(t, err)
 		require.NotEmpty(t, context.Stats())
-		require.NotZero(t, context.Stats().Timers["_dd.appsec.waf.run"])
+		require.NotZero(t, context.Stats().Timers["_dd.appsec.waf.decode"])
 		require.NotZero(t, context.Stats().Timers["_dd.appsec.waf.encode.persistent"])
 		require.NotZero(t, context.Stats().Timers["_dd.appsec.waf.encode.ephemeral"])
 		require.NotZero(t, context.Stats().Timers["_dd.appsec.waf.duration_ext"])
@@ -390,7 +390,7 @@ func TestTimeout(t *testing.T) {
 
 		_, err := context.Run(RunAddressData{Persistent: largeValue}, 0)
 		require.Equal(t, errors.ErrTimeout, err)
-		require.GreaterOrEqual(t, context.Stats().Timers["_dd.appsec.waf.run"], time.Millisecond)
+		require.GreaterOrEqual(t, context.Stats().Timers["_dd.appsec.waf.duration_ext"], time.Millisecond)
 		require.GreaterOrEqual(t, context.Stats().Timers["_dd.appsec.waf.encode.persistent"], time.Millisecond)
 		require.Equal(t, context.Stats().Timers["_dd.appsec.waf.encode.ephemeral"], time.Duration(0))
 	})
@@ -402,7 +402,7 @@ func TestTimeout(t *testing.T) {
 
 		_, err := context.Run(RunAddressData{Ephemeral: largeValue}, 0)
 		require.Equal(t, errors.ErrTimeout, err)
-		require.GreaterOrEqual(t, context.Stats().Timers["_dd.appsec.waf.run"], time.Millisecond)
+		require.GreaterOrEqual(t, context.Stats().Timers["_dd.appsec.waf.duration_ext"], time.Millisecond)
 		require.Equal(t, context.Stats().Timers["_dd.appsec.waf.encode.persistent"], time.Duration(0))
 		require.GreaterOrEqual(t, context.Stats().Timers["_dd.appsec.waf.encode.ephemeral"], time.Millisecond)
 	})

--- a/waf_test.go
+++ b/waf_test.go
@@ -377,8 +377,7 @@ func TestTimeout(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, context.Stats())
 		require.NotZero(t, context.Stats().Timers["_dd.appsec.waf.decode"])
-		require.NotZero(t, context.Stats().Timers["_dd.appsec.waf.encode.persistent"])
-		require.NotZero(t, context.Stats().Timers["_dd.appsec.waf.encode.ephemeral"])
+		require.NotZero(t, context.Stats().Timers["_dd.appsec.waf.encode"])
 		require.NotZero(t, context.Stats().Timers["_dd.appsec.waf.duration_ext"])
 		require.NotZero(t, context.Stats().Timers["_dd.appsec.waf.duration"])
 	})
@@ -391,8 +390,7 @@ func TestTimeout(t *testing.T) {
 		_, err := context.Run(RunAddressData{Persistent: largeValue}, 0)
 		require.Equal(t, errors.ErrTimeout, err)
 		require.GreaterOrEqual(t, context.Stats().Timers["_dd.appsec.waf.duration_ext"], time.Millisecond)
-		require.GreaterOrEqual(t, context.Stats().Timers["_dd.appsec.waf.encode.persistent"], time.Millisecond)
-		require.Equal(t, context.Stats().Timers["_dd.appsec.waf.encode.ephemeral"], time.Duration(0))
+		require.GreaterOrEqual(t, context.Stats().Timers["_dd.appsec.waf.encode"], time.Millisecond)
 	})
 
 	t.Run("timeout-ephemeral-encoder", func(t *testing.T) {
@@ -403,8 +401,7 @@ func TestTimeout(t *testing.T) {
 		_, err := context.Run(RunAddressData{Ephemeral: largeValue}, 0)
 		require.Equal(t, errors.ErrTimeout, err)
 		require.GreaterOrEqual(t, context.Stats().Timers["_dd.appsec.waf.duration_ext"], time.Millisecond)
-		require.Equal(t, context.Stats().Timers["_dd.appsec.waf.encode.persistent"], time.Duration(0))
-		require.GreaterOrEqual(t, context.Stats().Timers["_dd.appsec.waf.encode.ephemeral"], time.Millisecond)
+		require.GreaterOrEqual(t, context.Stats().Timers["_dd.appsec.waf.encode"], time.Millisecond)
 	})
 
 	t.Run("many-runs", func(t *testing.T) {


### PR DESCRIPTION
- [x] Setup timers to be retro-compatible with the old metrics
- [x] Add a decode metric
- [x] Fuse persistent and ephemeral encode metrics 