### PR TITLE
fix: report _dd.appsec.waf.duration even when the WAF does not match on anything

### DIFF
--- a/context.go
+++ b/context.go
@@ -261,7 +261,8 @@ func unwrapWafResult(ret bindings.WafReturnCode, result *bindings.WafResult) (re
 		res.Derivatives, err = decodeMap(&result.Derivatives)
 	}
 
-	res.TimeSpent = time.Duration(result.TotalRuntime)
+	res.TimeSpent = time.Duration(result.TotalRuntime) * time.Nanosecond
+
 	if ret == bindings.WafOK {
 		return res, err
 	}

--- a/context.go
+++ b/context.go
@@ -261,6 +261,7 @@ func unwrapWafResult(ret bindings.WafReturnCode, result *bindings.WafResult) (re
 		res.Derivatives, err = decodeMap(&result.Derivatives)
 	}
 
+	res.TimeSpent = time.Duration(result.TotalRuntime)
 	if ret == bindings.WafOK {
 		return res, err
 	}
@@ -282,7 +283,6 @@ func unwrapWafResult(ret bindings.WafReturnCode, result *bindings.WafResult) (re
 		}
 	}
 
-	res.TimeSpent = time.Duration(result.TotalRuntime)
 	return res, err
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -37,7 +37,7 @@ const (
 func (stats Stats) Metrics() map[string]any {
 	tags := make(map[string]any, len(stats.Timers)+len(stats.Truncations)+1)
 	for k, v := range stats.Timers {
-		tags[k] = uint64(v.Microseconds())
+		tags[k] = float64(v.Nanoseconds()) / float64(time.Microsecond) // The metrics should be in microseconds
 	}
 
 	tags[wafTimeoutTag] = stats.TimeoutCount

--- a/waf_test.go
+++ b/waf_test.go
@@ -368,12 +368,26 @@ func TestTimeout(t *testing.T) {
 		"my.input": "Arachni",
 	}
 
-	t.Run("not-empty-metricsStore", func(t *testing.T) {
-		context := NewContextWithBudget(waf, time.Millisecond)
+	t.Run("not-empty-metrics-match", func(t *testing.T) {
+		context := NewContextWithBudget(waf, time.Hour)
 		require.NotNil(t, context)
 		defer context.Close()
 
 		_, err := context.Run(RunAddressData{Persistent: normalValue, Ephemeral: normalValue}, 0)
+		require.NoError(t, err)
+		require.NotEmpty(t, context.Stats())
+		require.NotZero(t, context.Stats().Timers["_dd.appsec.waf.decode"])
+		require.NotZero(t, context.Stats().Timers["_dd.appsec.waf.encode"])
+		require.NotZero(t, context.Stats().Timers["_dd.appsec.waf.duration_ext"])
+		require.NotZero(t, context.Stats().Timers["_dd.appsec.waf.duration"])
+	})
+
+	t.Run("not-empty-metrics-no-match", func(t *testing.T) {
+		context := NewContextWithBudget(waf, time.Hour)
+		require.NotNil(t, context)
+		defer context.Close()
+
+		_, err := context.Run(RunAddressData{Persistent: map[string]any{"my.input": "curl/7.88"}}, 0)
 		require.NoError(t, err)
 		require.NotEmpty(t, context.Stats())
 		require.NotZero(t, context.Stats().Timers["_dd.appsec.waf.decode"])


### PR DESCRIPTION
- [x] Fix a bug that would make that the value of the metric `_dd.appsec.waf.duration` was zero because the time was never added to the struct
- [x] Put back the metrics in float64 to be backwards compatible (even though it should already work as it is) 