### PR TITLE
Ensure WAF static libraries get tracked in vendor/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@
 
 # Swap files
 *.swp
+
+## Ensure WAF static libraries are not excluded from vendor folders
+!internal/lib/*.so
+!internal/lib/*.dylib
+


### PR DESCRIPTION
Github's default [Go.gitignore](https://github.com/github/gitignore/blob/main/Go.gitignore#L8-L9) ignores `*.so` and `*.dylib` files. Projects using that default gitignore along with `go mod vendor` may find when adding the vendored files to git that the `libddwaf-linux-amd64.so` and related .so/.dylib files are skipped (resulting in later build failures due to missing .so files).

If we add these exclusion rules, it will ensure that projects using vendoring and the widely used gitignore rules will be prompted to track this libraries .so/.dylib files without any special effort.