### PR TITLE
refactor: go 1.20 spring cleanup

### DIFF
--- a/context.go
+++ b/context.go
@@ -14,7 +14,7 @@ import (
 	"github.com/DataDog/go-libddwaf/v2/internal/bindings"
 	"github.com/DataDog/go-libddwaf/v2/internal/unsafe"
 
-	"go.uber.org/atomic"
+	"sync/atomic"
 )
 
 // Context is a WAF execution context. It allows running the WAF incrementally
@@ -106,7 +106,7 @@ func (context *Context) Run(addressData RunAddressData, _ time.Duration) (res Re
 
 	defer func() {
 		if err == errors.ErrTimeout {
-			context.timeoutCount.Inc()
+			context.timeoutCount.Add(1)
 		}
 	}()
 

--- a/go.mod
+++ b/go.mod
@@ -4,15 +4,12 @@ go 1.20
 
 require (
 	github.com/ebitengine/purego v0.6.0-alpha.5
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4
-	go.uber.org/atomic v1.11.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,10 +3,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/ebitengine/purego v0.6.0-alpha.5 h1:EYID3JOAdmQ4SNZYJHu9V6IqOeRQDBYxqKAg9PyoHFY=
 github.com/ebitengine/purego v0.6.0-alpha.5/go.mod h1:ah1In8AOtksoNK6yk5z1HTJeUkC1Ez4Wk2idgGslMwQ=
-github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
-github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
-github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -19,8 +15,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
-go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
 golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/bindings/safe.go
+++ b/internal/bindings/safe.go
@@ -7,6 +7,8 @@ package bindings
 
 import (
 	wafErrors "github.com/DataDog/go-libddwaf/v2/errors"
+
+	"fmt"
 	"reflect"
 	"runtime"
 
@@ -36,7 +38,7 @@ func tryCall(f func() error) (err error) {
 		case string:
 			err = errors.New(actual)
 		default:
-			err = errors.Errorf("%v", r)
+			err = fmt.Errorf("%v", r)
 		}
 
 		err = newPanicError(f, err)

--- a/internal/support/waf_support.go
+++ b/internal/support/waf_support.go
@@ -5,6 +5,8 @@
 
 package support
 
+import "errors"
+
 // Errors used to report data using the Health function
 // Store all the errors related to why go-liddwaf is unavailable for the current target at runtime.
 var wafSupportErrors []error
@@ -12,10 +14,12 @@ var wafSupportErrors []error
 // Not nil if the build tag `datadog.no_waf` is set
 var wafManuallyDisabledErr error
 
-func WafSupportErrors() []error {
-	return wafSupportErrors
+// WafSupportErrors returns all the errors related to why go-liddwaf is unavailable for the current target at runtime.
+func WafSupportErrors() error {
+	return errors.Join(wafSupportErrors...)
 }
 
+// WafManuallyDisabledError returns an error if the build tag `datadog.no_waf` is set
 func WafManuallyDisabledError() error {
 	return wafManuallyDisabledErr
 }

--- a/internal/support/waf_support.go
+++ b/internal/support/waf_support.go
@@ -5,8 +5,6 @@
 
 package support
 
-import "errors"
-
 // Errors used to report data using the Health function
 // Store all the errors related to why go-liddwaf is unavailable for the current target at runtime.
 var wafSupportErrors []error
@@ -14,12 +12,10 @@ var wafSupportErrors []error
 // Not nil if the build tag `datadog.no_waf` is set
 var wafManuallyDisabledErr error
 
-// WafSupportErrors returns all the errors related to why go-liddwaf is unavailable for the current target at runtime.
-func WafSupportErrors() error {
-	return errors.Join(wafSupportErrors...)
+func WafSupportErrors() []error {
+	return wafSupportErrors
 }
 
-// WafManuallyDisabledError returns an error if the build tag `datadog.no_waf` is set
 func WafManuallyDisabledError() error {
 	return wafManuallyDisabledErr
 }

--- a/waf.go
+++ b/waf.go
@@ -6,6 +6,7 @@
 package waf
 
 import (
+	"errors"
 	"fmt"
 	wafErrors "github.com/DataDog/go-libddwaf/v2/errors"
 	"sync"
@@ -13,8 +14,6 @@ import (
 
 	"github.com/DataDog/go-libddwaf/v2/internal/bindings"
 	"github.com/DataDog/go-libddwaf/v2/internal/support"
-
-	"github.com/hashicorp/go-multierror"
 )
 
 // ErrTimeout is the error returned when the WAF times out while processing a request.
@@ -47,17 +46,16 @@ func (d *Diagnostics) TopLevelError() error {
 		"scanners":       d.Scanners,
 	}
 
-	var err *multierror.Error
+	var errs []error
 	for field, entry := range fields {
 		if entry == nil || entry.Error == "" {
 			// No entry or no error => we're all good.
 			continue
 		}
-		// TODO: rely on errors.Join() once go1.20 is our min supported Go version
-		err = multierror.Append(err, fmt.Errorf("in %#v: %s", field, entry.Error))
+		errs = append(errs, fmt.Errorf("in %#v: %s", field, entry.Error))
 	}
 
-	return err.ErrorOrNil()
+	return errors.Join(errs...)
 }
 
 // DiagnosticEntry stores the information - provided by the WAF - about loaded and failed rules
@@ -165,7 +163,7 @@ func (r *Result) HasActions() bool {
 // Otherwise, it returns false along with an error detailing why.
 func SupportsTarget() (bool, error) {
 	wafSupportErrors := support.WafSupportErrors()
-	return len(wafSupportErrors) == 0, multierror.Append(nil, wafSupportErrors...).ErrorOrNil()
+	return wafSupportErrors == nil, wafSupportErrors
 }
 
 // Health returns true if the waf is usable, false otherwise. At the same time it can return an error
@@ -176,20 +174,8 @@ func SupportsTarget() (bool, error) {
 // - The Waf library is not in an unsupported OS/Arch
 // - The Waf library is not in an unsupported Go version
 func Health() (bool, error) {
-	var err *multierror.Error
-	if wafLoadErr != nil {
-		err = multierror.Append(err, wafLoadErr)
-	}
-
 	wafSupportErrors := support.WafSupportErrors()
-	if len(wafSupportErrors) > 0 {
-		err = multierror.Append(err, wafSupportErrors...)
-	}
-
 	wafManuallyDisabledErr := support.WafManuallyDisabledError()
-	if wafManuallyDisabledErr != nil {
-		err = multierror.Append(err, wafManuallyDisabledErr)
-	}
 
-	return (wafLib != nil || wafLoadErr == nil) && len(wafSupportErrors) == 0 && wafManuallyDisabledErr == nil, err.ErrorOrNil()
+	return (wafLib != nil || wafLoadErr == nil) && wafSupportErrors == nil && wafManuallyDisabledErr == nil, errors.Join(wafLoadErr, wafSupportErrors, wafManuallyDisabledErr)
 }

--- a/waf.go
+++ b/waf.go
@@ -163,7 +163,7 @@ func (r *Result) HasActions() bool {
 // Otherwise, it returns false along with an error detailing why.
 func SupportsTarget() (bool, error) {
 	wafSupportErrors := support.WafSupportErrors()
-	return wafSupportErrors == nil, wafSupportErrors
+	return wafSupportErrors == nil, errors.Join(wafSupportErrors...)
 }
 
 // Health returns true if the waf is usable, false otherwise. At the same time it can return an error
@@ -174,7 +174,7 @@ func SupportsTarget() (bool, error) {
 // - The Waf library is not in an unsupported OS/Arch
 // - The Waf library is not in an unsupported Go version
 func Health() (bool, error) {
-	wafSupportErrors := support.WafSupportErrors()
+	wafSupportErrors := errors.Join(support.WafSupportErrors()...)
 	wafManuallyDisabledErr := support.WafManuallyDisabledError()
 
 	return (wafLib != nil || wafLoadErr == nil) && wafSupportErrors == nil && wafManuallyDisabledErr == nil, errors.Join(wafLoadErr, wafSupportErrors, wafManuallyDisabledErr)


### PR DESCRIPTION
- [x] Replace the multierror package by `errors.Join` since go 1.20 is our minimal supported version now
- [x] Remove usage of `go.uber.org/atomic` in favor of `sync/atomic`