### PR TITLE
(chore): move to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ func main() {
         Persistent: map[string]any{
             "server.request.path_params": "/rfiinc.txt",
         },
-    }, time.Minute)
+    })
 }
 ```
 

--- a/alignement_test.go
+++ b/alignement_test.go
@@ -11,8 +11,8 @@ package waf
 import (
 	"testing"
 
-	"github.com/DataDog/go-libddwaf/v2/internal/bindings"
-	"github.com/DataDog/go-libddwaf/v2/internal/unsafe"
+	"github.com/DataDog/go-libddwaf/v3/internal/bindings"
+	"github.com/DataDog/go-libddwaf/v3/internal/unsafe"
 
 	"github.com/ebitengine/purego"
 	"github.com/stretchr/testify/require"

--- a/cgo_ref_pool.go
+++ b/cgo_ref_pool.go
@@ -8,8 +8,8 @@ package waf
 import (
 	"strconv"
 
-	"github.com/DataDog/go-libddwaf/v2/internal/bindings"
-	"github.com/DataDog/go-libddwaf/v2/internal/unsafe"
+	"github.com/DataDog/go-libddwaf/v3/internal/bindings"
+	"github.com/DataDog/go-libddwaf/v3/internal/unsafe"
 )
 
 // cgoRefPool is a way to make sure we can safely send go allocated data on the C side of the WAF

--- a/context.go
+++ b/context.go
@@ -9,10 +9,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DataDog/go-libddwaf/v2/errors"
-	"github.com/DataDog/go-libddwaf/v2/internal/bindings"
-	"github.com/DataDog/go-libddwaf/v2/internal/unsafe"
-	"github.com/DataDog/go-libddwaf/v2/timer"
+	"github.com/DataDog/go-libddwaf/v3/errors"
+	"github.com/DataDog/go-libddwaf/v3/internal/bindings"
+	"github.com/DataDog/go-libddwaf/v3/internal/unsafe"
+	"github.com/DataDog/go-libddwaf/v3/timer"
 
 	"sync/atomic"
 )

--- a/decoder.go
+++ b/decoder.go
@@ -6,9 +6,9 @@
 package waf
 
 import (
-	"github.com/DataDog/go-libddwaf/v2/errors"
-	"github.com/DataDog/go-libddwaf/v2/internal/bindings"
-	"github.com/DataDog/go-libddwaf/v2/internal/unsafe"
+	"github.com/DataDog/go-libddwaf/v3/errors"
+	"github.com/DataDog/go-libddwaf/v3/internal/bindings"
+	"github.com/DataDog/go-libddwaf/v3/internal/unsafe"
 )
 
 // decodeErrors transforms the wafObject received by the wafRulesetInfo after the call to wafDl.wafInit to a map where

--- a/encoder.go
+++ b/encoder.go
@@ -8,7 +8,6 @@ package waf
 import (
 	"context"
 	"fmt"
-	"github.com/DataDog/go-libddwaf/v3/timer"
 	"math"
 	"reflect"
 	"strings"
@@ -18,6 +17,7 @@ import (
 	"github.com/DataDog/go-libddwaf/v3/errors"
 	"github.com/DataDog/go-libddwaf/v3/internal/bindings"
 	"github.com/DataDog/go-libddwaf/v3/internal/unsafe"
+	"github.com/DataDog/go-libddwaf/v3/timer"
 )
 
 // Encode Go values into wafObjects. Only the subset of Go types representable into wafObjects

--- a/encoder.go
+++ b/encoder.go
@@ -8,16 +8,16 @@ package waf
 import (
 	"context"
 	"fmt"
-	"github.com/DataDog/go-libddwaf/v2/timer"
+	"github.com/DataDog/go-libddwaf/v3/timer"
 	"math"
 	"reflect"
 	"strings"
 	"time"
 	"unicode"
 
-	"github.com/DataDog/go-libddwaf/v2/errors"
-	"github.com/DataDog/go-libddwaf/v2/internal/bindings"
-	"github.com/DataDog/go-libddwaf/v2/internal/unsafe"
+	"github.com/DataDog/go-libddwaf/v3/errors"
+	"github.com/DataDog/go-libddwaf/v3/internal/bindings"
+	"github.com/DataDog/go-libddwaf/v3/internal/unsafe"
 )
 
 // Encode Go values into wafObjects. Only the subset of Go types representable into wafObjects

--- a/encoder_decoder_test.go
+++ b/encoder_decoder_test.go
@@ -10,15 +10,15 @@ package waf
 import (
 	"context"
 	"encoding/json"
-	"github.com/DataDog/go-libddwaf/v2/timer"
+	"github.com/DataDog/go-libddwaf/v3/timer"
 	"reflect"
 	"sort"
 	"testing"
 	"time"
 
-	"github.com/DataDog/go-libddwaf/v2/errors"
-	"github.com/DataDog/go-libddwaf/v2/internal/bindings"
-	"github.com/DataDog/go-libddwaf/v2/internal/unsafe"
+	"github.com/DataDog/go-libddwaf/v3/errors"
+	"github.com/DataDog/go-libddwaf/v3/internal/bindings"
+	"github.com/DataDog/go-libddwaf/v3/internal/unsafe"
 
 	"github.com/stretchr/testify/require"
 )

--- a/encoder_decoder_test.go
+++ b/encoder_decoder_test.go
@@ -10,7 +10,6 @@ package waf
 import (
 	"context"
 	"encoding/json"
-	"github.com/DataDog/go-libddwaf/v3/timer"
 	"reflect"
 	"sort"
 	"testing"
@@ -19,6 +18,7 @@ import (
 	"github.com/DataDog/go-libddwaf/v3/errors"
 	"github.com/DataDog/go-libddwaf/v3/internal/bindings"
 	"github.com/DataDog/go-libddwaf/v3/internal/unsafe"
+	"github.com/DataDog/go-libddwaf/v3/timer"
 
 	"github.com/stretchr/testify/require"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/DataDog/go-libddwaf/v2
+module github.com/DataDog/go-libddwaf/v3
 
 go 1.20
 
@@ -16,6 +16,3 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-// Version where import paths were not changed to go-libddwaf/v2
-retract v2.0.0

--- a/handle.go
+++ b/handle.go
@@ -10,10 +10,10 @@ import (
 	"fmt"
 	"time"
 
-	wafErrors "github.com/DataDog/go-libddwaf/v2/errors"
-	"github.com/DataDog/go-libddwaf/v2/internal/bindings"
-	"github.com/DataDog/go-libddwaf/v2/internal/unsafe"
-	"github.com/DataDog/go-libddwaf/v2/timer"
+	wafErrors "github.com/DataDog/go-libddwaf/v3/errors"
+	"github.com/DataDog/go-libddwaf/v3/internal/bindings"
+	"github.com/DataDog/go-libddwaf/v3/internal/unsafe"
+	"github.com/DataDog/go-libddwaf/v3/timer"
 
 	"sync/atomic"
 )

--- a/internal/bindings/safe.go
+++ b/internal/bindings/safe.go
@@ -6,7 +6,7 @@
 package bindings
 
 import (
-	wafErrors "github.com/DataDog/go-libddwaf/v2/errors"
+	wafErrors "github.com/DataDog/go-libddwaf/v3/errors"
 
 	"fmt"
 	"reflect"

--- a/internal/bindings/safe_test.go
+++ b/internal/bindings/safe_test.go
@@ -7,7 +7,7 @@ package bindings
 
 import (
 	"errors"
-	wafErrors "github.com/DataDog/go-libddwaf/v2/errors"
+	wafErrors "github.com/DataDog/go-libddwaf/v3/errors"
 	"strconv"
 	"testing"
 

--- a/internal/bindings/waf_dl.go
+++ b/internal/bindings/waf_dl.go
@@ -11,9 +11,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/DataDog/go-libddwaf/v2/internal/lib"
-	"github.com/DataDog/go-libddwaf/v2/internal/log"
-	"github.com/DataDog/go-libddwaf/v2/internal/unsafe"
+	"github.com/DataDog/go-libddwaf/v3/internal/lib"
+	"github.com/DataDog/go-libddwaf/v3/internal/log"
+	"github.com/DataDog/go-libddwaf/v3/internal/unsafe"
 	"github.com/ebitengine/purego"
 )
 

--- a/internal/bindings/waf_dl_test.go
+++ b/internal/bindings/waf_dl_test.go
@@ -15,7 +15,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/DataDog/go-libddwaf/v2/internal/lib"
+	"github.com/DataDog/go-libddwaf/v3/internal/lib"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/log/log_cgo.go
+++ b/internal/log/log_cgo.go
@@ -17,7 +17,7 @@ package log
 //   uint64_t message_len
 // );
 import "C"
-import "github.com/DataDog/go-libddwaf/v2/internal/unsafe"
+import "github.com/DataDog/go-libddwaf/v3/internal/unsafe"
 
 // CallbackFunctionPointer returns a pointer to the log callback function which
 // can be used with libddwaf.

--- a/internal/log/log_purego.go
+++ b/internal/log/log_purego.go
@@ -8,7 +8,7 @@
 package log
 
 import (
-	"github.com/DataDog/go-libddwaf/v2/internal/unsafe"
+	"github.com/DataDog/go-libddwaf/v3/internal/unsafe"
 	"sync"
 
 	"github.com/ebitengine/purego"

--- a/internal/support/waf_cgo_disabled.go
+++ b/internal/support/waf_cgo_disabled.go
@@ -9,7 +9,7 @@
 
 package support
 
-import "github.com/DataDog/go-libddwaf/v2/errors"
+import "github.com/DataDog/go-libddwaf/v3/errors"
 
 func init() {
 	wafSupportErrors = append(wafSupportErrors, errors.CgoDisabledError{})

--- a/internal/support/waf_cgo_disabled_test.go
+++ b/internal/support/waf_cgo_disabled_test.go
@@ -10,8 +10,8 @@ package support_test
 import (
 	"testing"
 
-	waf "github.com/DataDog/go-libddwaf/v2"
-	"github.com/DataDog/go-libddwaf/v2/errors"
+	waf "github.com/DataDog/go-libddwaf/v3"
+	"github.com/DataDog/go-libddwaf/v3/errors"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/support/waf_manually_disabled.go
+++ b/internal/support/waf_manually_disabled.go
@@ -8,7 +8,7 @@
 
 package support
 
-import "github.com/DataDog/go-libddwaf/v2/errors"
+import "github.com/DataDog/go-libddwaf/v3/errors"
 
 func init() {
 	wafManuallyDisabledErr = errors.ManuallyDisabledError{}

--- a/internal/support/waf_manually_disabled_test.go
+++ b/internal/support/waf_manually_disabled_test.go
@@ -8,10 +8,10 @@
 package support_test
 
 import (
-	"github.com/DataDog/go-libddwaf/v2/errors"
+	"github.com/DataDog/go-libddwaf/v3/errors"
 	"testing"
 
-	waf "github.com/DataDog/go-libddwaf/v2"
+	waf "github.com/DataDog/go-libddwaf/v3"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/support/waf_manually_disabled_test.go
+++ b/internal/support/waf_manually_disabled_test.go
@@ -8,10 +8,11 @@
 package support_test
 
 import (
-	"github.com/DataDog/go-libddwaf/v3/errors"
 	"testing"
 
 	waf "github.com/DataDog/go-libddwaf/v3"
+	"github.com/DataDog/go-libddwaf/v3/errors"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/support/waf_unsupported_go.go
+++ b/internal/support/waf_unsupported_go.go
@@ -8,7 +8,7 @@
 
 package support
 
-import "github.com/DataDog/go-libddwaf/v2/errors"
+import "github.com/DataDog/go-libddwaf/v3/errors"
 
 func init() {
 	wafSupportErrors = append(wafSupportErrors, errors.UnsupportedGoVersionError{})

--- a/internal/support/waf_unsupported_go_test.go
+++ b/internal/support/waf_unsupported_go_test.go
@@ -11,8 +11,8 @@ import (
 	"runtime"
 	"testing"
 
-	waf "github.com/DataDog/go-libddwaf/v2"
-	"github.com/DataDog/go-libddwaf/v2/errors"
+	waf "github.com/DataDog/go-libddwaf/v3"
+	"github.com/DataDog/go-libddwaf/v3/errors"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/support/waf_unsupported_target.go
+++ b/internal/support/waf_unsupported_target.go
@@ -12,7 +12,7 @@ package support
 import (
 	"runtime"
 
-	"github.com/DataDog/go-libddwaf/v2/errors"
+	"github.com/DataDog/go-libddwaf/v3/errors"
 )
 
 func init() {

--- a/internal/support/waf_unsupported_target_test.go
+++ b/internal/support/waf_unsupported_target_test.go
@@ -11,8 +11,8 @@ import (
 	"runtime"
 	"testing"
 
-	waf "github.com/DataDog/go-libddwaf/v2"
-	"github.com/DataDog/go-libddwaf/v2/errors"
+	waf "github.com/DataDog/go-libddwaf/v3"
+	"github.com/DataDog/go-libddwaf/v3/errors"
 	"github.com/stretchr/testify/require"
 )
 

--- a/timer/clock_test.go
+++ b/timer/clock_test.go
@@ -1,9 +1,10 @@
 package timer
 
 import (
-	"github.com/DataDog/go-libddwaf/v3/internal/unsafe"
 	"testing"
 	"time"
+
+	"github.com/DataDog/go-libddwaf/v3/internal/unsafe"
 )
 
 func BenchmarkMostUsedFunctions(b *testing.B) {

--- a/timer/clock_test.go
+++ b/timer/clock_test.go
@@ -1,7 +1,7 @@
 package timer
 
 import (
-	"github.com/DataDog/go-libddwaf/v2/internal/unsafe"
+	"github.com/DataDog/go-libddwaf/v3/internal/unsafe"
 	"testing"
 	"time"
 )

--- a/timer/timer_test.go
+++ b/timer/timer_test.go
@@ -6,8 +6,8 @@
 package timer_test
 
 import (
-	"github.com/DataDog/go-libddwaf/v2/internal/unsafe"
-	"github.com/DataDog/go-libddwaf/v2/timer"
+	"github.com/DataDog/go-libddwaf/v3/internal/unsafe"
+	"github.com/DataDog/go-libddwaf/v3/timer"
 	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"

--- a/timer/timer_test.go
+++ b/timer/timer_test.go
@@ -6,12 +6,14 @@
 package timer_test
 
 import (
-	"github.com/DataDog/go-libddwaf/v3/internal/unsafe"
-	"github.com/DataDog/go-libddwaf/v3/timer"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/DataDog/go-libddwaf/v3/internal/unsafe"
+	"github.com/DataDog/go-libddwaf/v3/timer"
+
+	"github.com/stretchr/testify/require"
 )
 
 func hasExpired(t *testing.T, timer timer.Timer, duration time.Duration) {

--- a/waf.go
+++ b/waf.go
@@ -8,10 +8,10 @@ package waf
 import (
 	"errors"
 	"fmt"
-	wafErrors "github.com/DataDog/go-libddwaf/v3/errors"
 	"sync"
 	"time"
 
+	wafErrors "github.com/DataDog/go-libddwaf/v3/errors"
 	"github.com/DataDog/go-libddwaf/v3/internal/bindings"
 	"github.com/DataDog/go-libddwaf/v3/internal/support"
 )

--- a/waf.go
+++ b/waf.go
@@ -8,12 +8,12 @@ package waf
 import (
 	"errors"
 	"fmt"
-	wafErrors "github.com/DataDog/go-libddwaf/v2/errors"
+	wafErrors "github.com/DataDog/go-libddwaf/v3/errors"
 	"sync"
 	"time"
 
-	"github.com/DataDog/go-libddwaf/v2/internal/bindings"
-	"github.com/DataDog/go-libddwaf/v2/internal/support"
+	"github.com/DataDog/go-libddwaf/v3/internal/bindings"
+	"github.com/DataDog/go-libddwaf/v3/internal/support"
 )
 
 // ErrTimeout is the error returned when the WAF times out while processing a request.

--- a/waf_support_test.go
+++ b/waf_support_test.go
@@ -9,8 +9,8 @@ package waf
 
 import (
 	"flag"
-	wafErrors "github.com/DataDog/go-libddwaf/v2/errors"
-	"github.com/DataDog/go-libddwaf/v2/internal/support"
+	wafErrors "github.com/DataDog/go-libddwaf/v3/errors"
+	"github.com/DataDog/go-libddwaf/v3/internal/support"
 	"github.com/stretchr/testify/require"
 	"testing"
 )

--- a/waf_support_test.go
+++ b/waf_support_test.go
@@ -9,10 +9,12 @@ package waf
 
 import (
 	"flag"
+	"testing"
+
 	wafErrors "github.com/DataDog/go-libddwaf/v3/errors"
 	"github.com/DataDog/go-libddwaf/v3/internal/support"
+
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 var (

--- a/waf_test.go
+++ b/waf_test.go
@@ -12,7 +12,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
-	"github.com/DataDog/go-libddwaf/v2/timer"
+	"github.com/DataDog/go-libddwaf/v3/timer"
 	"math/rand"
 	"sort"
 	"strconv"
@@ -22,10 +22,10 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/DataDog/go-libddwaf/v2/errors"
+	"github.com/DataDog/go-libddwaf/v3/errors"
 
-	"github.com/DataDog/go-libddwaf/v2/internal/bindings"
-	"github.com/DataDog/go-libddwaf/v2/internal/lib"
+	"github.com/DataDog/go-libddwaf/v3/internal/bindings"
+	"github.com/DataDog/go-libddwaf/v3/internal/lib"
 	"github.com/stretchr/testify/require"
 )
 

--- a/waf_test.go
+++ b/waf_test.go
@@ -12,7 +12,6 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
-	"github.com/DataDog/go-libddwaf/v3/timer"
 	"math/rand"
 	"sort"
 	"strconv"
@@ -23,9 +22,10 @@ import (
 	"time"
 
 	"github.com/DataDog/go-libddwaf/v3/errors"
-
 	"github.com/DataDog/go-libddwaf/v3/internal/bindings"
 	"github.com/DataDog/go-libddwaf/v3/internal/lib"
+	"github.com/DataDog/go-libddwaf/v3/timer"
+
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
JIRA: APPSEC-52726

### Changes

Update go.mod and module references to go-libbdwaf v3 version.