### PR TITLE
fix: stop passing empty strings as null ptrs

### DIFF
--- a/cgo_ref_pool.go
+++ b/cgo_ref_pool.go
@@ -27,6 +27,11 @@ type cgoRefPool struct {
 	arrayRefs  [][]bindings.WafObject
 }
 
+// This is used when passing empty Go strings to the WAF in order to avoid passing null string pointers,
+// which are not handled by the WAF in all cases.
+// FIXME: to be removed when the WAF handles null ptr strings in all expected places
+var emptyWAFStringValue = unsafe.NativeStringUnwrap("\x00").Data
+
 func (refPool *cgoRefPool) append(newRefs cgoRefPool) {
 	refPool.stringRefs = append(refPool.stringRefs, newRefs.stringRefs...)
 	refPool.arrayRefs = append(refPool.arrayRefs, newRefs.arrayRefs...)
@@ -51,7 +56,8 @@ func (refPool *cgoRefPool) AllocWafString(obj *bindings.WafObject, str string) {
 
 	if len(str) == 0 {
 		obj.NbEntries = 0
-		obj.Value = 1
+		// FIXME: use obj.Value = 0 when the WAF handles null string ptr in all expected places
+		obj.Value = emptyWAFStringValue
 		return
 	}
 

--- a/cgo_ref_pool.go
+++ b/cgo_ref_pool.go
@@ -51,7 +51,7 @@ func (refPool *cgoRefPool) AllocWafString(obj *bindings.WafObject, str string) {
 
 	if len(str) == 0 {
 		obj.NbEntries = 0
-		obj.Value = 0
+		obj.Value = 1
 		return
 	}
 


### PR DESCRIPTION
Empty strings would be passed as null waf string objects, which the WAF doesn't handle in all cases.
While we wait for a WAF update to properly handle this, we set the waf object value for empty go strings to a null terminated empty C string representation.
This is band-aid solution that should get discarded once the WAF handles nullptr strings in all expected cases.