### PR TITLE
fix conflicting symbols between v2 & v3

### DIFF
--- a/internal/log/log_cgo.go
+++ b/internal/log/log_cgo.go
@@ -8,7 +8,7 @@
 package log
 
 // #include "./ddwaf.h"
-// extern void ddwafLogCallbackFn(
+// extern void ddwafLogCallbackFnv3(
 //   DDWAF_LOG_LEVEL level,
 //   char* function,
 //   char* file,
@@ -22,11 +22,11 @@ import "github.com/DataDog/go-libddwaf/v3/internal/unsafe"
 // CallbackFunctionPointer returns a pointer to the log callback function which
 // can be used with libddwaf.
 func CallbackFunctionPointer() uintptr {
-	return uintptr(C.ddwafLogCallbackFn)
+	return uintptr(C.ddwafLogCallbackFnv3)
 }
 
-//export ddwafLogCallbackFn
-func ddwafLogCallbackFn(level C.DDWAF_LOG_LEVEL, fnPtr, filePtr *C.char, line C.unsigned, msgPtr *C.char, _ C.uint64_t) {
+//export ddwafLogCallbackFnv3
+func ddwafLogCallbackFnv3(level C.DDWAF_LOG_LEVEL, fnPtr, filePtr *C.char, line C.unsigned, msgPtr *C.char, _ C.uint64_t) {
 	function := unsafe.Gostring(unsafe.CastNative[C.char, byte](fnPtr))
 	file := unsafe.Gostring(unsafe.CastNative[C.char, byte](filePtr))
 	message := unsafe.Gostring(unsafe.CastNative[C.char, byte](msgPtr))


### PR DESCRIPTION
Go semantic versionning makes it that we can have multiple major versions of the same module in the same binary. Since we exported an hard-coded symbol it breaks this possibility. This should not happen in practice for customers because noone is using go-libddwaf as-is except dd-trace-go & some DataDog backend code

The error:
```
/usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/bin/ld: /tmp/go-link-2237125540/000030.o: in function `ddwafLogCallbackFn':
/tmp/go-build/_cgo_export.c:27: multiple definition of `ddwafLogCallbackFn'; /tmp/go-link-2237125540/000023.o:/tmp/go-build/_cgo_export.c:27: first defined here
```