### PR TITLE
ci: remove deprecated runner macos-11

### DIFF
--- a/.github/workflows/_test_bare_metal.yml
+++ b/.github/workflows/_test_bare_metal.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ macos-14, macos-13, macos-12, macos-11, ubuntu-22.04, ubuntu-20.04, windows-latest, arm-4core-linux ]
+        runs-on: [ macos-14, macos-13, macos-12, ubuntu-22.04, ubuntu-20.04, windows-latest, arm-4core-linux ]
         go-version: [ '1.22', '1.21', '1.20' ]
         include:
           # Test with DD_APPSEC_WAF_LOG_LEVEL (only latest go version)


### PR DESCRIPTION
Remove `macos-11` runners because there are under brownout from GitHub.