### PR TITLE
chore: unlock go 1.23

### DIFF
--- a/.github/workflows/_test_containerized.yml
+++ b/.github/workflows/_test_containerized.yml
@@ -16,10 +16,10 @@ jobs:
           - golang:{0}-buster
           # RPM-based image
           - amazonlinux:2 # pretty popular on AWS workloads
-        go-version: [ "1.22", "1.21", "1.20" ]
+        go-version: [ "1.23-rc", "1.22", "1.21", "1.20" ]
         include:
           # Test with DD_APPSEC_WAF_LOG_LEVEL (only latest go, without any particular tag)
-          - go-version: '1.22'
+          - go-version: '1.23-rc'
             waf-log-level: TRACE
         exclude:
           # Prune inexistent build images (debian buster is on LTS but won't get new go version images)
@@ -28,10 +28,13 @@ jobs:
            # Prune inexistent build images (debian buster is on LTS but won't get new go version images)
           - go-version: '1.22'
             image: golang:{0}-buster
-          # The amazonlinux:2 variant is only relevant for the default go version yum ships (currently 1.20)
+          # Prune inexistent build images (debian buster is on LTS but won't get new go version images)
+          - go-version: '1.23-rc'
+            image: golang:{0}-buster
+          # The amazonlinux:2 variant is only relevant for the default go version yum ships (currently 1.22)
           - go-version: '1.21'
             image: amazonlinux:2
-          - go-version: '1.22'
+          - go-version: '1.20'
             image: amazonlinux:2
     name: ${{ matrix.arch }} ${{ format(matrix.image, matrix.go-version) }} go${{ matrix.go-version }}${{ matrix.waf-log-level && format(' (DD_APPSEC_WAF_LOG_LEVEL={0})', matrix.waf-log-level) || '' }}
     # We use ARM runners when needed to avoid the performance hit of QEMU

--- a/.github/workflows/ci.sh
+++ b/.github/workflows/ci.sh
@@ -8,21 +8,21 @@ GOOS="$(go env GOOS)"
 GOARCH="$(go env GOARCH)"
 
 case $GOVERSION in
-    *1.20*|*1.19* ) CGOCHECK="GODEBUG=cgocheck=2";;
+    *1.20* ) CGOCHECK="GODEBUG=cgocheck=2";;
     *) CGOCHECK="GOEXPERIMENT=cgocheck2";;
 esac
 
-has_cgo() {
+contains() {
     case $1 in
-        *cgo*) echo 1;;
-        *) echo 0;;
+        *$2*) echo true;;
+        *) echo false;;
     esac
 }
 
 # Return true if the current OS is not Windows
 WAF_ENABLED=$([ "$GOOS" = "windows" ] && echo false || echo true)
 
-# run is tne main function that runs the tests
+# run is the main function that runs the tests
 # It takes 2 arguments:
 # - $1: whether the WAF is enabled or not (true or false)
 # - $2: the tags to use for the tests (e.g. "appsec,cgo")
@@ -31,22 +31,29 @@ run() {
     tags="ci,$(echo "$2" | sed 's/cgo//')"
     nproc=$(getconf _NPROCESSORS_ONLN)
     test_tags="$2,$GOOS,$GOARCH"
-    cgo=$(has_cgo "$2")
+    cgo=$($(contains "$2" cgo) && echo 1 || echo 0)
+
+    # Go 1.23 does not allow go version build tags
+    if $(contains "$GOVERSION" go1.23) && $(contains "$test_tags" go1); then
+        return
+    fi
 
     echo "Running matrix $test_tags where the WAF is" "$($waf_enabled && echo "supported" || echo "not supported")" "..."
     env CGO_ENABLED="$cgo" go test -shuffle=on -tags="$tags" -args -waf-build-tags="$test_tags" -waf-supported="$waf_enabled" ./...
 
-    if $waf_enabled; then
-        if [ "$cgo" = "1" ]; then
-            echo "Running again with cgocheck enabled..."
-            env "$CGOCHECK" CGO_ENABLED=1 go test -shuffle=on -tags="$tags" -args -waf-build-tags="$test_tags" -waf-supported="$waf_enabled" ./...
-        fi
+    if ! $waf_enabled; then
+        return
+    fi
 
-        # TODO: remove condition once we have native arm64 linux runners
-        if [ "$GOARCH" = "amd64" ]; then
-            echo "Running again $nproc times in parralel"
-            env CGO_ENABLED="$cgo" go test -shuffle=on -parallel $((nproc / 4 + 1)) -count="$nproc" -tags="$tags" -args -waf-build-tags="$test_tags" -waf-supported="$waf_enabled" ./...
-        fi
+    if [ "$cgo" = "1" ]; then
+        echo "Running again with cgocheck enabled..."
+        env "$CGOCHECK" CGO_ENABLED=1 go test -shuffle=on -tags="$tags" -args -waf-build-tags="$test_tags" -waf-supported="$waf_enabled" ./...
+    fi
+
+    # TODO: remove condition once we have native arm64 linux runners
+    if [ "$GOARCH" = "amd64" ]; then
+        echo "Running again $nproc times in parralel"
+        env CGO_ENABLED="$cgo" go test -shuffle=on -parallel $((nproc / 4 + 1)) -count="$nproc" -tags="$tags" -args -waf-build-tags="$test_tags" -waf-supported="$waf_enabled" ./...
     fi
 }
 

--- a/.github/workflows/ci.sh
+++ b/.github/workflows/ci.sh
@@ -52,12 +52,12 @@ run() {
 
 run "$WAF_ENABLED" appsec                # WAF enabled (but not on windows)
 run false                                # CGO Disabled
-run false go1.23                         # Too recent go version (not tested)
-run false go1.23,appsec                  # CGO disabled with appsec explicitely enabled but too recent go version
+run false go1.24                         # Too recent go version (not tested)
+run false go1.24,appsec                  # CGO disabled with appsec explicitely enabled but too recent go version
 run false datadog.no_waf                 # WAF manually disabled
 run false datadog.no_waf,appsec          # CGO disabled with appsec explicitely enabled but WAF manually disabled
-run false datadog.no_waf,go1.23          # WAF manually disabled and go version to recent
-run false datadog.no_waf,go1.23,appsec   # CGO disabled, WAF manually disabled, too recent go version with appsec explicitely enabled
+run false datadog.no_waf,go1.24          # WAF manually disabled and go version to recent
+run false datadog.no_waf,go1.24,appsec   # CGO disabled, WAF manually disabled, too recent go version with appsec explicitely enabled
 
 # Check if we are running on Alpine and install the required dependencies for cgo
 if [ -f /etc/os-release ] && grep -q Alpine < /etc/os-release; then
@@ -65,6 +65,6 @@ if [ -f /etc/os-release ] && grep -q Alpine < /etc/os-release; then
 fi
 
 run "$WAF_ENABLED" cgo                   # WAF enabled (but not on windows)
-run false go1.23,cgo                     # CGO enabled and too recent go version
+run false go1.24,cgo                     # CGO enabled and too recent go version
 run false datadog.no_waf,cgo             # WAF manually disabled and CGO enabled
-run false datadog.no_waf,go1.23,cgo      # CGO enabled, WAF manually disabled, too recent go version
+run false datadog.no_waf,go1.24,cgo      # CGO enabled, WAF manually disabled, too recent go version

--- a/_tools/libddwaf-updater/update.go
+++ b/_tools/libddwaf-updater/update.go
@@ -32,7 +32,7 @@ var (
 )
 
 const (
-	goVersionUnsupported = "go1.23"
+	goVersionUnsupported = "go1.24"
 )
 
 var (

--- a/alignement_test.go
+++ b/alignement_test.go
@@ -4,7 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Purego only works on linux/macOS with amd64 and arm64 from now
-//go:build (linux || darwin) && (amd64 || arm64) && !go1.23 && !datadog.no_waf && (cgo || appsec)
+//go:build (linux || darwin) && (amd64 || arm64) && !go1.24 && !datadog.no_waf && (cgo || appsec)
 
 package waf
 

--- a/encoder_decoder_test.go
+++ b/encoder_decoder_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (amd64 || arm64) && (linux || darwin) && !go1.23 && !datadog.no_waf && (cgo || appsec)
+//go:build (amd64 || arm64) && (linux || darwin) && !go1.24 && !datadog.no_waf && (cgo || appsec)
 
 package waf
 

--- a/handle_test.go
+++ b/handle_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (amd64 || arm64) && (linux || darwin) && !go1.23 && !datadog.no_waf && (cgo || appsec)
+//go:build (amd64 || arm64) && (linux || darwin) && !go1.24 && !datadog.no_waf && (cgo || appsec)
 
 package waf
 

--- a/internal/bindings/waf_dl.go
+++ b/internal/bindings/waf_dl.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (linux || darwin) && (amd64 || arm64) && !go1.23 && !datadog.no_waf && (cgo || appsec)
+//go:build (linux || darwin) && (amd64 || arm64) && !go1.24 && !datadog.no_waf && (cgo || appsec)
 
 package bindings
 

--- a/internal/bindings/waf_dl_test.go
+++ b/internal/bindings/waf_dl_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (linux || darwin) && (amd64 || arm64) && !go1.23 && !datadog.no_waf && (cgo || appsec)
+//go:build (linux || darwin) && (amd64 || arm64) && !go1.24 && !datadog.no_waf && (cgo || appsec)
 
 package bindings
 

--- a/internal/bindings/waf_dl_unsupported.go
+++ b/internal/bindings/waf_dl_unsupported.go
@@ -4,7 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Build when the target OS or architecture are not supported
-//go:build (!linux && !darwin) || (!amd64 && !arm64) || go1.23 || datadog.no_waf || (!cgo && !appsec)
+//go:build (!linux && !darwin) || (!amd64 && !arm64) || go1.24 || datadog.no_waf || (!cgo && !appsec)
 
 package bindings
 

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build ((darwin && (amd64 || arm64)) || (linux && (amd64 || arm64))) && !go1.23 && !datadog.no_waf && (cgo || appsec)
+//go:build ((darwin && (amd64 || arm64)) || (linux && (amd64 || arm64))) && !go1.24 && !datadog.no_waf && (cgo || appsec)
 
 package lib
 

--- a/internal/lib/lib_darwin_amd64.go
+++ b/internal/lib/lib_darwin_amd64.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build darwin && amd64 && !go1.23 && !datadog.no_waf && (cgo || appsec)
+//go:build darwin && amd64 && !go1.24 && !datadog.no_waf && (cgo || appsec)
 
 package lib
 

--- a/internal/lib/lib_darwin_arm64.go
+++ b/internal/lib/lib_darwin_arm64.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build darwin && arm64 && !go1.23 && !datadog.no_waf && (cgo || appsec)
+//go:build darwin && arm64 && !go1.24 && !datadog.no_waf && (cgo || appsec)
 
 package lib
 

--- a/internal/lib/lib_linux_amd64.go
+++ b/internal/lib/lib_linux_amd64.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux && amd64 && !go1.23 && !datadog.no_waf && (cgo || appsec)
+//go:build linux && amd64 && !go1.24 && !datadog.no_waf && (cgo || appsec)
 
 package lib
 

--- a/internal/lib/lib_linux_arm64.go
+++ b/internal/lib/lib_linux_arm64.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux && arm64 && !go1.23 && !datadog.no_waf && (cgo || appsec)
+//go:build linux && arm64 && !go1.24 && !datadog.no_waf && (cgo || appsec)
 
 package lib
 

--- a/internal/log/log_purego.go
+++ b/internal/log/log_purego.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !cgo && (darwin || freebsd) && !datadog.no_waf && !go1.23
+//go:build !cgo && (darwin || freebsd) && !datadog.no_waf && !go1.24
 
 package log
 

--- a/internal/log/log_unsupported.go
+++ b/internal/log/log_unsupported.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (!cgo && ((!darwin && !freebsd) || go1.23)) || datadog.no_waf
+//go:build (!cgo && ((!darwin && !freebsd) || go1.24)) || datadog.no_waf
 
 package log
 

--- a/internal/support/waf_unsupported_go.go
+++ b/internal/support/waf_unsupported_go.go
@@ -4,7 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Unsupported Go versions (>=)
-//go:build go1.23
+//go:build go1.24
 
 package support
 

--- a/internal/support/waf_unsupported_go_test.go
+++ b/internal/support/waf_unsupported_go_test.go
@@ -3,12 +3,11 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build go1.23
+//go:build go1.24
 
 package support_test
 
 import (
-	"runtime"
 	"testing"
 
 	waf "github.com/DataDog/go-libddwaf/v3"

--- a/internal/support/waf_unsupported_target_test.go
+++ b/internal/support/waf_unsupported_target_test.go
@@ -8,7 +8,6 @@
 package support_test
 
 import (
-	"runtime"
 	"testing"
 
 	waf "github.com/DataDog/go-libddwaf/v3"

--- a/waf_test.go
+++ b/waf_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (amd64 || arm64) && (linux || darwin) && !go1.23 && !datadog.no_waf && (cgo || appsec)
+//go:build (amd64 || arm64) && (linux || darwin) && !go1.24 && !datadog.no_waf && (cgo || appsec)
 
 package waf
 


### PR DESCRIPTION
- [x] run `sed -i 's/go1.23/go1.24/' **/*.go` to update built tags
- [x] Add `go1.23-rc` to the CI 
- [x] Remove some unused imports
- [x] Refactor CI script to workaround a new compilation error when trying to compile files with `go.1XX` build tags 