### PR TITLE
refactor: set go 1.21 as minimal supported version

### DIFF
--- a/.github/workflows/_test_bare_metal.yml
+++ b/.github/workflows/_test_bare_metal.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ macos-14, macos-13, macos-12, ubuntu-22.04, ubuntu-20.04, windows-latest, arm-4core-linux ]
-        go-version: [ '1.22', '1.21', '1.20' ]
+        go-version: [ '1.22', '1.21' ]
         include:
           # Test with DD_APPSEC_WAF_LOG_LEVEL (only latest go version)
           - go-version: '1.22'

--- a/.github/workflows/_test_containerized.yml
+++ b/.github/workflows/_test_containerized.yml
@@ -16,7 +16,7 @@ jobs:
           - golang:{0}-buster
           # RPM-based image
           - amazonlinux:2 # pretty popular on AWS workloads
-        go-version: [ "1.23-rc", "1.22", "1.21", "1.20" ]
+        go-version: [ "1.23-rc", "1.22", "1.21" ]
         include:
           # Test with DD_APPSEC_WAF_LOG_LEVEL (only latest go, without any particular tag)
           - go-version: '1.23-rc'
@@ -33,8 +33,6 @@ jobs:
             image: golang:{0}-buster
           # The amazonlinux:2 variant is only relevant for the default go version yum ships (currently 1.22)
           - go-version: '1.21'
-            image: amazonlinux:2
-          - go-version: '1.20'
             image: amazonlinux:2
     name: ${{ matrix.arch }} ${{ format(matrix.image, matrix.go-version) }} go${{ matrix.go-version }}${{ matrix.waf-log-level && format(' (DD_APPSEC_WAF_LOG_LEVEL={0})', matrix.waf-log-level) || '' }}
     # We use ARM runners when needed to avoid the performance hit of QEMU

--- a/.github/workflows/ci.sh
+++ b/.github/workflows/ci.sh
@@ -7,11 +7,6 @@ GOVERSION="$(go env GOVERSION)"
 GOOS="$(go env GOOS)"
 GOARCH="$(go env GOARCH)"
 
-case $GOVERSION in
-    *1.20* ) CGOCHECK="GODEBUG=cgocheck=2";;
-    *) CGOCHECK="GOEXPERIMENT=cgocheck2";;
-esac
-
 contains() {
     case $1 in
         *$2*) echo true;;
@@ -47,7 +42,7 @@ run() {
 
     if [ "$cgo" = "1" ]; then
         echo "Running again with cgocheck enabled..."
-        env "$CGOCHECK" CGO_ENABLED=1 go test -shuffle=on -tags="$tags" -args -waf-build-tags="$test_tags" -waf-supported="$waf_enabled" ./...
+        env "GOEXPERIMENT=cgocheck2" CGO_ENABLED=1 go test -shuffle=on -tags="$tags" -args -waf-build-tags="$test_tags" -waf-supported="$waf_enabled" ./...
     fi
 
     # TODO: remove condition once we have native arm64 linux runners

--- a/encoder.go
+++ b/encoder.go
@@ -446,14 +446,6 @@ func depthOf(ctx context.Context, obj reflect.Value) (depth int, err error) {
 
 	obj, kind := resolvePointer(obj)
 
-	//TODO: Remove this once Go 1.21 is the minimum supported version (it adds `builtin.max`)
-	max := func(x, y int) int {
-		if x > y {
-			return x
-		}
-		return y
-	}
-
 	var itemDepth int
 	switch kind {
 	case reflect.Array, reflect.Slice:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/go-libddwaf/v3
 
-go 1.20
+go 1.21
 
 require (
 	github.com/ebitengine/purego v0.6.0-alpha.5

--- a/internal/bindings/waf_dl.go
+++ b/internal/bindings/waf_dl.go
@@ -44,7 +44,6 @@ type wafSymbols struct {
 // The caller is responsible for calling wafDl.Close on the returned object once they
 // are done with it so that associated resources can be released.
 func NewWafDl() (dl *WafDl, err error) {
-	var handle uintptr
 	file, err := lib.DumpEmbeddedWAF()
 	if err != nil {
 		return
@@ -55,6 +54,7 @@ func NewWafDl() (dl *WafDl, err error) {
 		}
 	}()
 
+	var handle uintptr
 	if handle, err = purego.Dlopen(file, purego.RTLD_GLOBAL|purego.RTLD_NOW); err != nil {
 		return
 	}

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -10,6 +10,7 @@ package lib
 import (
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -28,20 +29,17 @@ func DumpEmbeddedWAF() (path string, err error) {
 	path = file.Name()
 
 	defer func() {
+		allErrors := []error{err}
 		if closeErr := file.Close(); closeErr != nil {
-			if err != nil {
-				// TODO: rely on errors.Join() once go1.20 is our min supported Go version
-				err = fmt.Errorf("%w; along with an error while releasingclosing the temporary file: %v", err, closeErr)
-			} else {
-				err = fmt.Errorf("error closing file: %w", closeErr)
-			}
+			allErrors = append(allErrors, fmt.Errorf("error closing file: %w", closeErr))
 		}
 		if path != "" && err != nil {
 			if rmErr := os.Remove(path); rmErr != nil {
-				// TODO: rely on errors.Join() once go1.20 is our min supported Go version
-				err = fmt.Errorf("%w; along with an error while releasingclosing the temporary file: %v", err, rmErr)
+				allErrors = append(allErrors, fmt.Errorf("error removing file: %w", rmErr))
 			}
 		}
+
+		err = errors.Join(allErrors...)
 	}()
 
 	gr, err := gzip.NewReader(bytes.NewReader(libddwaf))

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -29,17 +29,14 @@ func DumpEmbeddedWAF() (path string, err error) {
 	path = file.Name()
 
 	defer func() {
-		allErrors := []error{err}
 		if closeErr := file.Close(); closeErr != nil {
-			allErrors = append(allErrors, fmt.Errorf("error closing file: %w", closeErr))
+			err = errors.Join(err, fmt.Errorf("error closing file: %w", closeErr))
 		}
 		if path != "" && err != nil {
 			if rmErr := os.Remove(path); rmErr != nil {
-				allErrors = append(allErrors, fmt.Errorf("error removing file: %w", rmErr))
+				err = errors.Join(err, fmt.Errorf("error removing file: %w", rmErr))
 			}
 		}
-
-		err = errors.Join(allErrors...)
 	}()
 
 	gr, err := gzip.NewReader(bytes.NewReader(libddwaf))

--- a/waf.go
+++ b/waf.go
@@ -33,7 +33,7 @@ type Diagnostics struct {
 	Version        string
 }
 
-// TopLevelErrors returns the list of top-level errors reported by the WAF on any of the Diagnostics
+// TopLevelError returns the list of top-level errors reported by the WAF on any of the Diagnostics
 // entries, rolled up into a single error value. Returns nil if no top-level errors were reported.
 // Individual, item-level errors might still exist.
 func (d *Diagnostics) TopLevelError() error {


### PR DESCRIPTION
- [x] Upgrade go mod to 1.21
- [x] Remove go 1.20 from CI
- [x] use `errors.Join` when necessary
- [x] use builtin `max` when necessary    