### PR TITLE
refactor: use runtime.Pinner instead of object slices

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -82,6 +82,7 @@ type native interface {
 func newLimitedEncoder(timer timer.Timer) encoder {
 	return encoder{
 		timer:            timer,
+		cgoRefs:          newCgoRefPool(),
 		containerMaxSize: bindings.WafMaxContainerSize,
 		stringMaxSize:    bindings.WafMaxStringLength,
 		objectMaxDepth:   bindings.WafMaxContainerDepth,
@@ -92,6 +93,7 @@ func newMaxEncoder() encoder {
 	timer, _ := timer.NewTimer(timer.WithUnlimitedBudget())
 	return encoder{
 		timer:            timer,
+		cgoRefs:          newCgoRefPool(),
 		containerMaxSize: math.MaxInt,
 		stringMaxSize:    math.MaxInt,
 		objectMaxDepth:   math.MaxInt,

--- a/internal/unsafe/utils.go
+++ b/internal/unsafe/utils.go
@@ -31,6 +31,16 @@ func NativeStringUnwrap(str string) reflect.StringHeader {
 	return *(*reflect.StringHeader)(stdUnsafe.Pointer(&str))
 }
 
+// StringData calls unsafe.StringData
+func StringData(str string) *byte {
+	return stdUnsafe.StringData(str)
+}
+
+// SliceData calls unsafe.SliceData
+func SliceData[T any](slice []T) *T {
+	return stdUnsafe.SliceData(slice)
+}
+
 func GostringSized(ptr *byte, size uint64) string {
 	if ptr == nil {
 		return ""


### PR DESCRIPTION
- [x] replace the content of the `cgoRefPool` struct
- [x] use `runtime.Pinner.Unpin()` where necessary
- [x] Remove usage of `runtime.KeepAlive`   