### PR TITLE
chore: unlock go 1.24

### DIFF
--- a/.github/workflows/_test_bare_metal.yml
+++ b/.github/workflows/_test_bare_metal.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ macos-15, macos-14, macos-13, ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, windows-latest, arm-4core-linux ]
+        runs-on: [ macos-15, macos-14, macos-13, ubuntu-24.04, ubuntu-22.04, windows-latest, arm-4core-linux ]
         go-version: [ stable, oldstable ]
         include:
           # Test with DD_APPSEC_WAF_LOG_LEVEL (only latest go version)

--- a/.github/workflows/_test_containerized.yml
+++ b/.github/workflows/_test_containerized.yml
@@ -31,23 +31,14 @@ jobs:
           - golang:{0}-alpine
           - golang:{0}-bookworm
           - golang:{0}-bullseye
-          # RPM-based image
-          - amazonlinux:2 # pretty popular on AWS workloads
-          - amazonlinux:2023
         go-version:
           - ${{ needs.go-versions.outputs.stable }}
           - ${{ needs.go-versions.outputs.oldstable }}
+          - tip
         include:
           # Test with DD_APPSEC_WAF_LOG_LEVEL (only latest go, without any particular tag)
           - go-version: ${{ needs.go-versions.outputs.stable }}
             waf-log-level: TRACE
-        exclude:
-          # The amazonlinux:2 variant is only relevant for the default go version yum ships (currently 1.22)
-          - go-version: ${{ needs.go-versions.outputs.stable }}
-            image: amazonlinux:2
-          # The amazonlinux:2023 variant is only relevant for the default go version yum ships (currently 1.22)
-          - go-version: ${{ needs.go-versions.outputs.stable }}
-            image: amazonlinux:2023
     name: ${{ matrix.arch }} ${{ format(matrix.image, matrix.go-version) }} go${{ matrix.go-version }}${{ matrix.waf-log-level && format(' (DD_APPSEC_WAF_LOG_LEVEL={0})', matrix.waf-log-level) || '' }}
     # We use ARM runners when needed to avoid the performance hit of QEMU
     runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-latest' || 'arm-4core-linux' }}

--- a/_tools/libddwaf-updater/update.go
+++ b/_tools/libddwaf-updater/update.go
@@ -32,7 +32,7 @@ var (
 )
 
 const (
-	goVersionUnsupported = "go1.24"
+	goVersionUnsupported = "go1.25"
 )
 
 var (

--- a/alignement_test.go
+++ b/alignement_test.go
@@ -4,7 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Purego only works on linux/macOS with amd64 and arm64 from now
-//go:build (linux || darwin) && (amd64 || arm64) && !go1.24 && !datadog.no_waf && (cgo || appsec)
+//go:build (linux || darwin) && (amd64 || arm64) && !go1.25 && !datadog.no_waf && (cgo || appsec)
 
 package waf
 

--- a/encoder.go
+++ b/encoder.go
@@ -491,7 +491,7 @@ func depthOf(ctx context.Context, obj reflect.Value) (depth int, err error) {
 	}
 }
 
-// resovlePointer attempts to resolve a pointer while limiting the pointer depth
+// resolvePointer attempts to resolve a pointer while limiting the pointer depth
 // to be traversed, so that this is not susceptible to an infinite loop when
 // provided a self-referencing pointer.
 func resolvePointer(obj reflect.Value) (reflect.Value, reflect.Kind) {

--- a/encoder_decoder_test.go
+++ b/encoder_decoder_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (amd64 || arm64) && (linux || darwin) && !go1.24 && !datadog.no_waf && (cgo || appsec)
+//go:build (amd64 || arm64) && (linux || darwin) && !go1.25 && !datadog.no_waf && (cgo || appsec)
 
 package waf
 

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/DataDog/go-libddwaf/v3
 
-go 1.21
+go 1.23
 
 require (
-	github.com/ebitengine/purego v0.6.0-alpha.5
+	github.com/ebitengine/purego v0.8.2
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/sys v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/ebitengine/purego v0.6.0-alpha.5 h1:EYID3JOAdmQ4SNZYJHu9V6IqOeRQDBYxqKAg9PyoHFY=
-github.com/ebitengine/purego v0.6.0-alpha.5/go.mod h1:ah1In8AOtksoNK6yk5z1HTJeUkC1Ez4Wk2idgGslMwQ=
+github.com/ebitengine/purego v0.8.2 h1:jPPGWs2sZ1UgOSgD2bClL0MJIqu58nOmIcBuXr62z1I=
+github.com/ebitengine/purego v0.8.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/handle_test.go
+++ b/handle_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (amd64 || arm64) && (linux || darwin) && !go1.24 && !datadog.no_waf && (cgo || appsec)
+//go:build (amd64 || arm64) && (linux || darwin) && !go1.25 && !datadog.no_waf && (cgo || appsec)
 
 package waf
 

--- a/internal/bindings/ctypes.go
+++ b/internal/bindings/ctypes.go
@@ -5,6 +5,10 @@
 
 package bindings
 
+import (
+	"structs"
+)
+
 const (
 	WafMaxStringLength   = 4096
 	WafMaxContainerDepth = 20
@@ -22,7 +26,7 @@ const (
 	WafMatch
 )
 
-// wafObjectType is an enum in C which has the size of DWORD.
+// WafObjectType is an enum in C which has the size of DWORD.
 // But DWORD is 4 bytes in amd64 and arm64 so uint32 it is.
 type WafObjectType uint32
 
@@ -39,6 +43,7 @@ const (
 )
 
 type WafObject struct {
+	_                   structs.HostLayout
 	ParameterName       uintptr
 	ParameterNameLength uint64
 	Value               uintptr
@@ -53,50 +58,54 @@ type WafObject struct {
 	// packed (apart from breaking all tracers of course)
 }
 
-// isInvalid determines whether this WAF Object has the invalid type (which is the 0-value).
+// IsInvalid determines whether this WAF Object has the invalid type (which is the 0-value).
 func (w *WafObject) IsInvalid() bool {
 	return w.Type == WafInvalidType
 }
 
-// isNil determines whether this WAF Object is nil or not.
+// IsNil determines whether this WAF Object is nil or not.
 func (w *WafObject) IsNil() bool {
 	return w.Type == WafNilType
 }
 
-// isArray determines whether this WAF Object is an array or not.
+// IsArray determines whether this WAF Object is an array or not.
 func (w *WafObject) IsArray() bool {
 	return w.Type == WafArrayType
 }
 
-// isMap determines whether this WAF Object is a map or not.
+// IsMap determines whether this WAF Object is a map or not.
 func (w *WafObject) IsMap() bool {
 	return w.Type == WafMapType
 }
 
 // IsUnusable returns true if the wafObject has no impact on the WAF execution
 // But we still need this kind of objects to forward map keys in case the value of the map is invalid
-func (wo *WafObject) IsUnusable() bool {
-	return wo.Type == WafInvalidType || wo.Type == WafNilType
+func (w *WafObject) IsUnusable() bool {
+	return w.Type == WafInvalidType || w.Type == WafNilType
 }
 
 type WafConfig struct {
+	_          structs.HostLayout
 	Limits     WafConfigLimits
 	Obfuscator WafConfigObfuscator
 	FreeFn     uintptr
 }
 
 type WafConfigLimits struct {
+	_                 structs.HostLayout
 	MaxContainerSize  uint32
 	MaxContainerDepth uint32
 	MaxStringLength   uint32
 }
 
 type WafConfigObfuscator struct {
+	_          structs.HostLayout
 	KeyRegex   uintptr // char *
 	ValueRegex uintptr // char *
 }
 
 type WafResult struct {
+	_            structs.HostLayout
 	Timeout      byte
 	Events       WafObject
 	Actions      WafObject
@@ -104,10 +113,10 @@ type WafResult struct {
 	TotalRuntime uint64
 }
 
-// wafHandle is a forward declaration in ddwaf.h header
+// WafHandle is a forward declaration in ddwaf.h header
 // We basically don't need to modify it, only to give it to the waf
 type WafHandle uintptr
 
-// wafContext is a forward declaration in ddwaf.h header
+// WafContext is a forward declaration in ddwaf.h header
 // We basically don't need to modify it, only to give it to the waf
 type WafContext uintptr

--- a/internal/bindings/waf_dl.go
+++ b/internal/bindings/waf_dl.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (linux || darwin) && (amd64 || arm64) && !go1.24 && !datadog.no_waf && (cgo || appsec)
+//go:build (linux || darwin) && (amd64 || arm64) && !go1.25 && !datadog.no_waf && (cgo || appsec)
 
 package bindings
 

--- a/internal/bindings/waf_dl_test.go
+++ b/internal/bindings/waf_dl_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (linux || darwin) && (amd64 || arm64) && !go1.24 && !datadog.no_waf && (cgo || appsec)
+//go:build (linux || darwin) && (amd64 || arm64) && !go1.25 && !datadog.no_waf && (cgo || appsec)
 
 package bindings
 

--- a/internal/bindings/waf_dl_unsupported.go
+++ b/internal/bindings/waf_dl_unsupported.go
@@ -4,52 +4,56 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Build when the target OS or architecture are not supported
-//go:build (!linux && !darwin) || (!amd64 && !arm64) || go1.24 || datadog.no_waf || (!cgo && !appsec)
+//go:build (!linux && !darwin) || (!amd64 && !arm64) || go1.25 || datadog.no_waf || (!cgo && !appsec)
 
 package bindings
 
+import (
+	"errors"
+)
+
 type WafDl struct{}
 
-func NewWafDl() (dl *WafDl, err error) {
-	return nil, nil
+func NewWafDl() (*WafDl, error) {
+	return nil, errors.New("WAF is not supported on this platform")
 }
 
 func (waf *WafDl) WafGetVersion() string {
 	return ""
 }
 
-func (waf *WafDl) WafInit(obj *WafObject, config *WafConfig, info *WafObject) WafHandle {
+func (waf *WafDl) WafInit(*WafObject, *WafConfig, *WafObject) WafHandle {
 	return 0
 }
 
-func (waf *WafDl) WafUpdate(handle WafHandle, ruleset *WafObject, info *WafObject) WafHandle {
+func (waf *WafDl) WafUpdate(WafHandle, *WafObject, *WafObject) WafHandle {
 	return 0
 }
 
-func (waf *WafDl) WafDestroy(handle WafHandle) {
+func (waf *WafDl) WafDestroy(WafHandle) {
 }
 
-func (waf *WafDl) WafKnownAddresses(handle WafHandle) []string {
+func (waf *WafDl) WafKnownAddresses(WafHandle) []string {
 	return nil
 }
 
-func (waf *WafDl) WafKnownActions(handle WafHandle) []string {
+func (waf *WafDl) WafKnownActions(WafHandle) []string {
 	return nil
 }
 
-func (waf *WafDl) WafContextInit(handle WafHandle) WafContext {
+func (waf *WafDl) WafContextInit(WafHandle) WafContext {
 	return 0
 }
 
-func (waf *WafDl) WafContextDestroy(context WafContext) {
+func (waf *WafDl) WafContextDestroy(WafContext) {
 }
 
-func (waf *WafDl) WafResultFree(result *WafResult) {
+func (waf *WafDl) WafResultFree(*WafResult) {
 }
 
-func (waf *WafDl) WafObjectFree(obj *WafObject) {
+func (waf *WafDl) WafObjectFree(*WafObject) {
 }
 
-func (waf *WafDl) WafRun(context WafContext, persistentData, ephemeralData *WafObject, result *WafResult, timeout uint64) WafReturnCode {
+func (waf *WafDl) WafRun(WafContext, *WafObject, *WafObject, *WafResult, uint64) WafReturnCode {
 	return WafErrInternal
 }

--- a/internal/lib/dump_waf_darwin.go
+++ b/internal/lib/dump_waf_darwin.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build darwin && (amd64 || arm64) && !go1.24 && !datadog.no_waf && (cgo || appsec)
+//go:build darwin && (amd64 || arm64) && !go1.25 && !datadog.no_waf && (cgo || appsec)
 
 package lib
 

--- a/internal/lib/dump_waf_linux.go
+++ b/internal/lib/dump_waf_linux.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux && (amd64 || arm64) && !go1.24 && !datadog.no_waf && (cgo || appsec)
+//go:build linux && (amd64 || arm64) && !go1.25 && !datadog.no_waf && (cgo || appsec)
 
 package lib
 

--- a/internal/lib/lib_darwin_amd64.go
+++ b/internal/lib/lib_darwin_amd64.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build darwin && amd64 && !go1.24 && !datadog.no_waf && (cgo || appsec)
+//go:build darwin && amd64 && !go1.25 && !datadog.no_waf && (cgo || appsec)
 
 package lib
 

--- a/internal/lib/lib_darwin_arm64.go
+++ b/internal/lib/lib_darwin_arm64.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build darwin && arm64 && !go1.24 && !datadog.no_waf && (cgo || appsec)
+//go:build darwin && arm64 && !go1.25 && !datadog.no_waf && (cgo || appsec)
 
 package lib
 

--- a/internal/lib/lib_linux_amd64.go
+++ b/internal/lib/lib_linux_amd64.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux && amd64 && !go1.24 && !datadog.no_waf && (cgo || appsec)
+//go:build linux && amd64 && !go1.25 && !datadog.no_waf && (cgo || appsec)
 
 package lib
 

--- a/internal/lib/lib_linux_arm64.go
+++ b/internal/lib/lib_linux_arm64.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux && arm64 && !go1.24 && !datadog.no_waf && (cgo || appsec)
+//go:build linux && arm64 && !go1.25 && !datadog.no_waf && (cgo || appsec)
 
 package lib
 

--- a/internal/log/log_purego.go
+++ b/internal/log/log_purego.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !cgo && (darwin || freebsd) && !datadog.no_waf && !go1.24
+//go:build !cgo && (darwin || freebsd) && !datadog.no_waf && !go1.25
 
 package log
 

--- a/internal/log/log_unsupported.go
+++ b/internal/log/log_unsupported.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (!cgo && ((!darwin && !freebsd) || go1.24)) || datadog.no_waf
+//go:build (!cgo && ((!darwin && !freebsd) || go1.25)) || datadog.no_waf
 
 package log
 

--- a/internal/support/waf_unsupported_go.go
+++ b/internal/support/waf_unsupported_go.go
@@ -4,7 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Unsupported Go versions (>=)
-//go:build go1.24
+//go:build go1.25
 
 package support
 

--- a/internal/support/waf_unsupported_go_test.go
+++ b/internal/support/waf_unsupported_go_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build go1.24
+//go:build go1.25
 
 package support_test
 

--- a/waf.go
+++ b/waf.go
@@ -122,8 +122,8 @@ var (
 // libddwaf is usable but some non-critical errors happened, such as failures
 // to remove temporary files. It is safe to continue using libddwaf in such
 // case.
-func Load() (ok bool, err error) {
-	if ok, err = Health(); !ok {
+func Load() (bool, error) {
+	if ok, err := Health(); !ok {
 		return false, err
 	}
 

--- a/waf_test.go
+++ b/waf_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (amd64 || arm64) && (linux || darwin) && !go1.24 && !datadog.no_waf && (cgo || appsec)
+//go:build (amd64 || arm64) && (linux || darwin) && !go1.25 && !datadog.no_waf && (cgo || appsec)
 
 package waf
 


### PR DESCRIPTION
- [x] Change builds tags
- [x] Change go mod
- [x] Upgrade purego
- [x] Remove runs from ci.sh that were running fake `go*` build tags to simulatre running on a higher go version because go does not allow us anymore
- [x] add structs.HostLayout from go 1.23
- [x] Fix some typos  