### PR TITLE
fix: sync names for telemetry

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -60,11 +60,11 @@ const (
 func (reason TruncationReason) String() string {
 	switch reason {
 	case ObjectTooDeep:
-		return "depth"
+		return "container_depth"
 	case ContainerTooLarge:
-		return "container-size"
+		return "container_size"
 	case StringTooLong:
-		return "string-size"
+		return "string_length"
 	default:
 		return fmt.Sprintf("TruncationReason(%v)", int(reason))
 	}

--- a/errors/waf.go
+++ b/errors/waf.go
@@ -52,6 +52,15 @@ func (e RunError) Error() string {
 	return description
 }
 
+// ToWafErrorCode converts an error to a WAF error code, returns zero if the error is not a WAF run error.
+func ToWafErrorCode(in error) int {
+	var runError RunError
+	if !errors.As(in, &runError) {
+		return 0
+	}
+	return int(runError)
+}
+
 // PanicError is an error type wrapping a recovered panic value that happened
 // during a function call. Such error must be considered unrecoverable and be
 // used to try to gracefully abort. Keeping using this package after such an

--- a/metrics.go
+++ b/metrics.go
@@ -58,6 +58,7 @@ const (
 	wafDecodeTag     = "decode"
 	wafTimeoutTag    = "timeouts"
 	wafTruncationTag = "truncations"
+	raspTimeoutTag   = "timeout"
 )
 
 func dot(parts ...string) string {
@@ -77,7 +78,7 @@ func (stats Stats) Metrics() map[string]any {
 	}
 
 	if stats.TimeoutRASPCount > 0 {
-		tags[dot(string(RASPScope), wafTimeoutTag)] = stats.TimeoutRASPCount
+		tags[dot(string(RASPScope), raspTimeoutTag)] = stats.TimeoutRASPCount
 	}
 
 	for reason, list := range stats.Truncations {


### PR DESCRIPTION
- [x] Fix truncation names according to https://docs.google.com/document/d/1D4hkC0jwwUyeo0hEQgyKP54kM1LZU98GL8MaP60tQrA/edit?tab=t.0#heading=h.1d7dno3x9isj
- [x] Fix rasp timeout that should not have a 's' ........
- [x] Add helper function to get a waf error code from go error 