### PR TITLE
errors: improve error message for unsupported Go versions

### DIFF
--- a/errors/support.go
+++ b/errors/support.go
@@ -26,7 +26,10 @@ func (e UnsupportedOSArchError) Error() string {
 type UnsupportedGoVersionError struct{}
 
 func (e UnsupportedGoVersionError) Error() string {
-	return fmt.Sprintf("unsupported Go version: %s", runtime.Version())
+	return fmt.Sprintf(
+		"unsupported Go version: %s (try running `go get github.com/DataDog/go-libddwaf@latest`)",
+		runtime.Version(),
+	)
 }
 
 type CgoDisabledError struct{}


### PR DESCRIPTION
The error message now suggests running `go get github.com/DataDog/go-libddwaf@latest` to help users troubleshoot the issue when they are running a yet-to-be supported Go release.