### PR TITLE
refactor(timer): replace raw strings by timer.Key for futur use

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/DataDog/go-libddwaf/v4/timer"
 )
 
 // Stats stores the metrics collected by the WAF.
@@ -126,7 +128,7 @@ func (metrics *metricsStore) timers() map[string]time.Duration {
 }
 
 // merge merges the current metrics with new ones
-func (metrics *metricsStore) merge(scope Scope, other map[string]time.Duration) {
+func (metrics *metricsStore) merge(scope Scope, other map[timer.Key]time.Duration) {
 	metrics.mutex.Lock()
 	defer metrics.mutex.Unlock()
 	if metrics.data == nil {
@@ -134,7 +136,7 @@ func (metrics *metricsStore) merge(scope Scope, other map[string]time.Duration) 
 	}
 
 	for component, val := range other {
-		key := metricKey{scope, component}
+		key := metricKey{scope, string(component)}
 		prev, ok := metrics.data[key]
 		if !ok {
 			prev = 0

--- a/timer/base_timer.go
+++ b/timer/base_timer.go
@@ -26,7 +26,7 @@ type baseTimer struct {
 	parent NodeTimer
 
 	// componentName is the name of the component of the timer. It is used to store the time spent in the component and to propagate the stop of the timer to the parent timer.
-	componentName string
+	componentName Key
 
 	// spent is the time spent on the timer, set after calling stop
 	spent time.Duration

--- a/timer/component.go
+++ b/timer/component.go
@@ -11,12 +11,12 @@ import (
 
 // components store the data shared between child timers of the same component name
 type components struct {
-	lookup  map[string]*atomic.Int64
+	lookup  map[Key]*atomic.Int64
 	storage []atomic.Int64
 }
 
-func newComponents(names []string) components {
-	lookup := make(map[string]*atomic.Int64, len(names))
+func newComponents(names []Key) components {
+	lookup := make(map[Key]*atomic.Int64, len(names))
 	storage := make([]atomic.Int64, len(names))
 	for i, name := range names {
 		lookup[name] = &storage[i]

--- a/timer/config.go
+++ b/timer/config.go
@@ -26,7 +26,7 @@ type DynamicBudgetFunc func(timer NodeTimer) time.Duration
 type config struct {
 	dynamicBudget DynamicBudgetFunc
 	// components store all the components of the timer
-	components []string
+	components []Key
 	// budget is the time budget for the timer
 	budget time.Duration
 }
@@ -79,7 +79,7 @@ func WithInheritedSumBudget() Option {
 }
 
 // WithComponents is an Option that adds multiple components to the components list
-func WithComponents(components ...string) Option {
+func WithComponents(components ...Key) Option {
 	return func(c *config) {
 		c.components = append(c.components, components...)
 	}

--- a/timer/timer.go
+++ b/timer/timer.go
@@ -9,6 +9,9 @@ import (
 	"time"
 )
 
+// Key is used to key track of each component of a tree timer. It can be used create constants that can be used to identify components in the tree.
+type Key string
+
 // Timer is the default interface for all timers. NewTimer will provide you with a Timer.
 // Keep in mind that they are NOT thread-safe and once Stop() is called, the Timer cannot be restarted.
 type Timer interface {
@@ -83,32 +86,32 @@ type NodeTimer interface {
 	// A node timer is required to have at least one component. If no component is provided, it will return an error asking you to use NewLeaf instead.
 	// If no budget is provided, it will inherit the budget from its parent when calling Start().
 	// NewNode is thread-safe
-	NewNode(name string, options ...Option) (NodeTimer, error)
+	NewNode(name Key, options ...Option) (NodeTimer, error)
 
 	// NewLeaf creates a new Timer with the given name and options. The given name must match one of the component name of the parent timer.
 	// A leaf timer is forbidden to have components. If a component is provided, it will return an error asking you to use NewNode instead.
 	// If no budget is provided, it will inherit the budget from its parent when calling Start().
 	// NewLeaf is thread-safe
-	NewLeaf(name string, options ...Option) (Timer, error)
+	NewLeaf(name Key, options ...Option) (Timer, error)
 
 	// MustLeaf creates a new Timer with the given name and options.  The given name must match one of the component name of the parent timer.
 	// MustLeaf wraps a call to NewLeaf but will panic if the error is not nil.
 	// MustLeaf is thread-safe
-	MustLeaf(name string, options ...Option) Timer
+	MustLeaf(name Key, options ...Option) Timer
 
 	// AddTime adds the given duration to the component of the timer with the given name.
 	// AddTime is thread-safe
-	AddTime(name string, duration time.Duration)
+	AddTime(name Key, duration time.Duration)
 
 	// Stats returns a map of the time spent in each component of the timer.
 	// Stats is thread-safe
-	Stats() map[string]time.Duration
+	Stats() map[Key]time.Duration
 
 	// childStarted is used to propagate the start of a child timer to the parent timer through the whole tree.
 	childStarted()
 
 	// childStopped is used to propagate the time spent in a child timer to the parent timer through the whole tree.
-	childStopped(componentName string, duration time.Duration)
+	childStopped(componentName Key, duration time.Duration)
 
 	// now is a convenience wrapper to swap the time.Now() function for testing and performance purposes.
 	now() time.Time

--- a/timer/timer_test.go
+++ b/timer/timer_test.go
@@ -226,9 +226,9 @@ func TestInheritBudget(t *testing.T) {
 
 func TestTree(t *testing.T) {
 	t.Run("100-leafs", func(t *testing.T) {
-		components := make([]string, 100)
+		components := make([]timer.Key, 100)
 		for i := range components {
-			components[i] = strconv.Itoa(i)
+			components[i] = timer.Key(strconv.Itoa(i))
 		}
 
 		rootTimer, err := timer.NewTreeTimer(timer.WithBudget(time.Hour), timer.WithComponents(components...))
@@ -251,9 +251,9 @@ func TestTree(t *testing.T) {
 	})
 
 	t.Run("100-nodes-1-leaf", func(t *testing.T) {
-		components := make([]string, 100)
+		components := make([]timer.Key, 100)
 		for i := range components {
-			components[i] = strconv.Itoa(i)
+			components[i] = timer.Key(strconv.Itoa(i))
 		}
 
 		rootTimer, err := timer.NewTreeTimer(timer.WithBudget(time.Hour), timer.WithComponents(components...))
@@ -279,9 +279,9 @@ func TestTree(t *testing.T) {
 	})
 
 	t.Run("100-nodes-100-leaf", func(t *testing.T) {
-		components := make([]string, 100)
+		components := make([]timer.Key, 100)
 		for i := range components {
-			components[i] = strconv.Itoa(i)
+			components[i] = timer.Key(strconv.Itoa(i))
 		}
 
 		rootTimer, err := timer.NewTreeTimer(timer.WithBudget(time.Hour), timer.WithComponents(components...))


### PR DESCRIPTION
Introduction a new `timer.Key` type to better distinguish timer keys from the rest

Also remove a useless condition on `timer.NewNode` that will make testing the new API easier