### PR TITLE
refactor: change visibility to public of the decodeObject method

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -156,7 +156,8 @@ func decodeStringArray(obj *bindings.WAFObject) ([]string, error) {
 	return strArr, nil
 }
 
-func decodeObject(obj *bindings.WAFObject) (any, error) {
+// DecodeObject decodes a WAFObject into a native Go type.
+func DecodeObject(obj *WAFObject) (any, error) {
 	switch obj.Type {
 	case bindings.WAFMapType:
 		return decodeMap(obj)
@@ -175,7 +176,7 @@ func decodeObject(obj *bindings.WAFObject) (any, error) {
 	case bindings.WAFNilType:
 		return nil, nil
 	default:
-		return nil, fmt.Errorf("decodeObject: %w: %d", waferrors.ErrUnsupportedValue, obj.Type)
+		return nil, fmt.Errorf("DecodeObject: %w: %d", waferrors.ErrUnsupportedValue, obj.Type)
 	}
 }
 
@@ -192,7 +193,7 @@ func decodeArray(obj *bindings.WAFObject) ([]any, error) {
 
 	for i := uint64(0); i < obj.NbEntries; i++ {
 		objElem := unsafe.CastWithOffset[bindings.WAFObject](obj.Value, i)
-		val, err := decodeObject(objElem)
+		val, err := DecodeObject(objElem)
 		if err != nil {
 			return nil, err
 		}
@@ -215,7 +216,7 @@ func decodeMap(obj *bindings.WAFObject) (map[string]any, error) {
 	for i := uint64(0); i < obj.NbEntries; i++ {
 		objElem := unsafe.CastWithOffset[bindings.WAFObject](obj.Value, i)
 		key := unsafe.GostringSized(unsafe.Cast[byte](objElem.ParameterName), objElem.ParameterNameLength)
-		val, err := decodeObject(objElem)
+		val, err := DecodeObject(objElem)
 		if err != nil {
 			return nil, err
 		}

--- a/encoder_decoder_test.go
+++ b/encoder_decoder_test.go
@@ -78,7 +78,7 @@ func TestEncodable(t *testing.T) {
 		encoded, err := encoder.Encode(&input)
 
 		require.NoError(t, err, "unexpected error when encoding: %v", err)
-		val, err := decodeObject(encoded)
+		val, err := DecodeObject(encoded)
 		require.NoError(t, err, "unexpected error when decoding: %v", err)
 		require.True(t, reflect.DeepEqual(output, val), "expected %#v, got %#v", output, val)
 	})
@@ -426,7 +426,7 @@ func TestEncodeDecode(t *testing.T) {
 				}
 
 				require.NoError(t, err, "unexpected error when encoding: %v", err)
-				val, err := decodeObject(encoded)
+				val, err := DecodeObject(encoded)
 
 				if tc.DecodeError != nil {
 					require.Error(t, err, "expected a decoding error when decoding %v", tc.Input)
@@ -650,7 +650,7 @@ func TestEncoderLimits(t *testing.T) {
 
 			require.NoError(t, err, "unexpected error when encoding: %v", err)
 
-			val, err := decodeObject(encoded)
+			val, err := DecodeObject(encoded)
 			if tc.DecodeError != nil {
 				require.Error(t, err, "expected a decoding error when decoding %v", tc.DecodeError)
 				require.ErrorIs(t, err, tc.DecodeError)


### PR DESCRIPTION
Change the visibility of `decodeObject` in the decoder to allow external calls.
Use case:
- PR #123 introduced support for a new encoder.
   - In order to verify the new decoder’s output in tests, we need to call `decodeObject` directly.








