### PR TITLE
fix: diagnostics decoder improperly sets RulesData with ExclusionData diags

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -71,7 +71,7 @@ func decodeDiagnostics(obj *bindings.WAFObject) (Diagnostics, error) {
 		case "rules_data":
 			diags.RulesData, err = decodeFeature(objElem)
 		case "exclusion_data":
-			diags.RulesData, err = decodeFeature(objElem)
+			diags.ExclusionData, err = decodeFeature(objElem)
 		case "rules_override":
 			diags.RulesOverrides, err = decodeFeature(objElem)
 		case "processors":

--- a/diagnostics_test.go
+++ b/diagnostics_test.go
@@ -1,0 +1,35 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build (amd64 || arm64) && (linux || darwin) && !go1.25 && !datadog.no_waf && (cgo || appsec)
+
+package libddwaf
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeDiagnosticsExclusionData(t *testing.T) {
+	var pinner runtime.Pinner
+	defer pinner.Unpin()
+
+	encoder, err := newEncoder(newUnlimitedEncoderConfig(&pinner))
+	require.NoError(t, err)
+
+	obj, err := encoder.Encode(map[string]any{
+		"exclusion_data": map[string]any{
+			"loaded": []any{"id1"},
+		},
+	})
+	require.NoError(t, err)
+
+	diags, err := decodeDiagnostics(obj)
+	require.NoError(t, err)
+	require.NotNil(t, diags.ExclusionData)
+	require.Contains(t, diags.ExclusionData.Loaded, "id1")
+}


### PR DESCRIPTION
## Summary
- fix ExclusionData not set by decoder
- add unit test for ExclusionData diagnostics

## Testing
- `go test ./...` *(fails: no route to host)*

------
https://chatgpt.com/codex/tasks/task_b_684bd9514c1883288b790c72b6b57d5e