### PR TITLE
chore: support go1.25

### DIFF
--- a/.github/workflows/ci.sh
+++ b/.github/workflows/ci.sh
@@ -18,7 +18,7 @@ contains() {
 WAF_ENABLED=$([ "$GOOS" = "windows" ] && echo false || echo true)
 
 if $(contains "$GOVERSION" devel); then
-    WAF_ENABLED=false
+    WAF_ENABLED=maybe
 fi
 
 # run is the main function that runs the tests
@@ -32,7 +32,7 @@ run() {
     test_tags="$2,$GOOS,$GOARCH"
     cgo=$($(contains "$2" cgo) && echo 1 || echo 0)
 
-    echo "Running matrix $test_tags where the WAF is" "$($waf_enabled && echo "supported" || echo "not supported")" "..."
+    echo "Running matrix $test_tags where the WAF is enablement is ${waf_enabled}..."
     env CGO_ENABLED="$cgo" go test -shuffle=on -tags="$tags" -args -waf-build-tags="$test_tags" -waf-supported="$waf_enabled" ./...
 
     if ! $waf_enabled; then

--- a/_tools/libddwaf-updater/update.go
+++ b/_tools/libddwaf-updater/update.go
@@ -32,7 +32,7 @@ var (
 )
 
 const (
-	goVersionUnsupported = "go1.25"
+	goVersionUnsupported = "go1.26"
 )
 
 var (

--- a/alignement_test.go
+++ b/alignement_test.go
@@ -4,7 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Purego only works on linux/macOS with amd64 and arm64 from now
-//go:build (linux || darwin) && (amd64 || arm64) && !go1.25 && !datadog.no_waf && (cgo || appsec)
+//go:build (linux || darwin) && (amd64 || arm64) && !go1.26 && !datadog.no_waf && (cgo || appsec)
 
 package libddwaf
 

--- a/builder_test.go
+++ b/builder_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (amd64 || arm64) && (linux || darwin) && !go1.25 && !datadog.no_waf && (cgo || appsec)
+//go:build (amd64 || arm64) && (linux || darwin) && !go1.26 && !datadog.no_waf && (cgo || appsec)
 
 package libddwaf
 

--- a/encoder_decoder_test.go
+++ b/encoder_decoder_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (amd64 || arm64) && (linux || darwin) && !go1.25 && !datadog.no_waf && (cgo || appsec)
+//go:build (amd64 || arm64) && (linux || darwin) && !go1.26 && !datadog.no_waf && (cgo || appsec)
 
 package libddwaf
 

--- a/internal/bindings/libddwaf.go
+++ b/internal/bindings/libddwaf.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (linux || darwin) && (amd64 || arm64) && !go1.25 && !datadog.no_waf && (cgo || appsec)
+//go:build (linux || darwin) && (amd64 || arm64) && !go1.26 && !datadog.no_waf && (cgo || appsec)
 
 package bindings
 

--- a/internal/bindings/waf_dl.go
+++ b/internal/bindings/waf_dl.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (linux || darwin) && (amd64 || arm64) && !go1.25 && !datadog.no_waf && (cgo || appsec)
+//go:build (linux || darwin) && (amd64 || arm64) && !go1.26 && !datadog.no_waf && (cgo || appsec)
 
 package bindings
 

--- a/internal/bindings/waf_dl_test.go
+++ b/internal/bindings/waf_dl_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (linux || darwin) && (amd64 || arm64) && !go1.25 && !datadog.no_waf && (cgo || appsec)
+//go:build (linux || darwin) && (amd64 || arm64) && !go1.26 && !datadog.no_waf && (cgo || appsec)
 
 package bindings
 

--- a/internal/bindings/waf_dl_unsupported.go
+++ b/internal/bindings/waf_dl_unsupported.go
@@ -4,7 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Build when the target OS or architecture are not supported
-//go:build (!linux && !darwin) || (!amd64 && !arm64) || go1.25 || datadog.no_waf || (!cgo && !appsec)
+//go:build (!linux && !darwin) || (!amd64 && !arm64) || go1.26 || datadog.no_waf || (!cgo && !appsec)
 
 package bindings
 

--- a/internal/lib/dump_waf_darwin.go
+++ b/internal/lib/dump_waf_darwin.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build darwin && (amd64 || arm64) && !go1.25 && !datadog.no_waf && (cgo || appsec)
+//go:build darwin && (amd64 || arm64) && !go1.26 && !datadog.no_waf && (cgo || appsec)
 
 package lib
 

--- a/internal/lib/dump_waf_linux.go
+++ b/internal/lib/dump_waf_linux.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux && (amd64 || arm64) && !go1.25 && !datadog.no_waf && (cgo || appsec)
+//go:build linux && (amd64 || arm64) && !go1.26 && !datadog.no_waf && (cgo || appsec)
 
 package lib
 

--- a/internal/lib/lib_darwin_amd64.go
+++ b/internal/lib/lib_darwin_amd64.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build darwin && amd64 && !go1.25 && !datadog.no_waf && (cgo || appsec)
+//go:build darwin && amd64 && !go1.26 && !datadog.no_waf && (cgo || appsec)
 
 package lib
 

--- a/internal/lib/lib_darwin_arm64.go
+++ b/internal/lib/lib_darwin_arm64.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build darwin && arm64 && !go1.25 && !datadog.no_waf && (cgo || appsec)
+//go:build darwin && arm64 && !go1.26 && !datadog.no_waf && (cgo || appsec)
 
 package lib
 

--- a/internal/lib/lib_linux_amd64.go
+++ b/internal/lib/lib_linux_amd64.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux && amd64 && !go1.25 && !datadog.no_waf && (cgo || appsec)
+//go:build linux && amd64 && !go1.26 && !datadog.no_waf && (cgo || appsec)
 
 package lib
 

--- a/internal/lib/lib_linux_arm64.go
+++ b/internal/lib/lib_linux_arm64.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux && arm64 && !go1.25 && !datadog.no_waf && (cgo || appsec)
+//go:build linux && arm64 && !go1.26 && !datadog.no_waf && (cgo || appsec)
 
 package lib
 

--- a/internal/log/log_purego.go
+++ b/internal/log/log_purego.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !cgo && (darwin || freebsd) && !datadog.no_waf && !go1.25
+//go:build !cgo && (darwin || freebsd) && !datadog.no_waf && !go1.26
 
 package log
 

--- a/internal/log/log_unsupported.go
+++ b/internal/log/log_unsupported.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (!cgo && ((!darwin && !freebsd) || go1.25)) || datadog.no_waf
+//go:build (!cgo && ((!darwin && !freebsd) || go1.26)) || datadog.no_waf
 
 package log
 

--- a/internal/support/waf_unsupported_go.go
+++ b/internal/support/waf_unsupported_go.go
@@ -4,7 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Unsupported Go versions (>=)
-//go:build go1.25
+//go:build go1.26
 
 package support
 

--- a/internal/support/waf_unsupported_go_test.go
+++ b/internal/support/waf_unsupported_go_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build go1.25
+//go:build go1.26
 
 package support_test
 

--- a/waf_test.go
+++ b/waf_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (amd64 || arm64) && (linux || darwin) && !go1.25 && !datadog.no_waf && (cgo || appsec)
+//go:build (amd64 || arm64) && (linux || darwin) && !go1.26 && !datadog.no_waf && (cgo || appsec)
 
 package libddwaf
 


### PR DESCRIPTION
Allows go1.25 and introduces a "maybe supported" option in the CI script, as it's not certain whether a dev release is supported or not supported (and it being binary makes it impossible to do early testing).