### PR TITLE
chore: fix '-' serialization tag handling

### DIFF
--- a/_tools/libddwaf-updater/go.mod
+++ b/_tools/libddwaf-updater/go.mod
@@ -1,6 +1,6 @@
-module github.com/DataDog/go-libddwaf/libddwaf-updater
+module github.com/DataDog/go-libddwaf/_tools/libddwaf-updater
 
-go 1.20
+go 1.23.0
 
 require (
 	github.com/bitfield/script v0.22.0

--- a/_tools/ruleset-updater/go.mod
+++ b/_tools/ruleset-updater/go.mod
@@ -2,8 +2,6 @@ module github.com/DataDog/go-libddwaf/_tools/ruleset-updater
 
 go 1.23.0
 
-toolchain go1.24.3
-
 require (
 	github.com/google/go-github/v72 v72.0.0
 	github.com/iancoleman/orderedmap v0.3.0

--- a/encoder.go
+++ b/encoder.go
@@ -316,15 +316,18 @@ func getFieldNameFromType(field reflect.StructField) (string, bool) {
 		if !ok {
 			continue
 		}
+		if tag == "-" {
+			// Explicitly ignored, note that only "-" causes the field to be ignored,
+			// any qualifier ("-,omitempty" or event "-,") will cause the field to be
+			// actually named "-" instead of being ignored.
+			return "", false
+		}
 		contentTypeTag = true
 		tag, _, _ = strings.Cut(tag, ",")
 		switch tag {
 		case "":
 			// Nothing to do
 			continue
-		case "-":
-			// Explicitly ignored
-			return "", false
 		default:
 			return tag, true
 		}

--- a/encoder_decoder_test.go
+++ b/encoder_decoder_test.go
@@ -618,8 +618,9 @@ func TestEncoderLimits(t *testing.T) {
 				Ignored     string `json:"-"`
 				Transparent string `json:",omitempty"`
 				Renamed     string `json:"field"`
-			}{Ignored: "1", Transparent: "2", Renamed: "3"},
-			Output: map[string]any{"Transparent": "2", "field": "3"},
+				LiteralDash string `json:"-,"`
+			}{Ignored: "1", Transparent: "2", Renamed: "3", LiteralDash: "4"},
+			Output: map[string]any{"Transparent": "2", "field": "3", "-": "4"},
 		},
 		{
 			Name: "xml-tagged",


### PR DESCRIPTION
The `-` exclusion is only when `"-"` is as-is, not when it has trailers (e.g, `"-,"`)