### PR TITLE
chore: don't bake-in the default ruleset on Windows

### DIFF
--- a/.github/workflows/_test_bare_metal.yml
+++ b/.github/workflows/_test_bare_metal.yml
@@ -32,7 +32,7 @@ jobs:
         go-version: ${{ fromJson(needs.go-versions-matrix.outputs.json) }}
         include:
           # Test with DD_APPSEC_WAF_LOG_LEVEL (only latest go version)
-          - go-version: oldstable
+          - go-version: stable
             waf-log-level: TRACE
     name: ${{ matrix.runs-on }} ${{ matrix.go-version }}${{ matrix.waf-log-level && format(' (DD_APPSEC_WAF_LOG_LEVEL={0})', matrix.waf-log-level) || '' }}
     runs-on: ${{ matrix.runs-on }}

--- a/internal/ruleset/ruleset.go
+++ b/internal/ruleset/ruleset.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build linux || darwin
+
 package ruleset
 
 import (

--- a/internal/ruleset/ruleset_test.go
+++ b/internal/ruleset/ruleset_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build linux || darwin
+
 package ruleset
 
 import (

--- a/internal/ruleset/ruleset_unsupported.go
+++ b/internal/ruleset/ruleset_unsupported.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !(linux || darwin)
+
+package ruleset
+
+import (
+	"errors"
+	"runtime"
+
+	"github.com/DataDog/go-libddwaf/v4/internal/bindings"
+)
+
+func DefaultRuleset(pinner *runtime.Pinner) (bindings.WAFObject, error) {
+	return bindings.WAFObject{}, errors.New("the default ruleset is not available on unsupported platforms")
+}


### PR DESCRIPTION
This avoids risking to carry a large embedded JSON object on Windows binaries where it'll never be of any use. The DefaultRuleset function remains "live" because it's used by the Builder API which is part of the surface that is not / cannot be gated by a build tag.