### PR TITLE
feat(ruleset): don't embed the ruleset if the build tag datadog.no_waf is set

### DIFF
--- a/internal/ruleset/ruleset.go
+++ b/internal/ruleset/ruleset.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux || darwin
+//go:build (linux || darwin) && !datadog.no_waf
 
 package ruleset
 

--- a/internal/ruleset/ruleset_unsupported.go
+++ b/internal/ruleset/ruleset_unsupported.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !(linux || darwin)
+//go:build !(linux || darwin) || datadog.no_waf
 
 package ruleset
 


### PR DESCRIPTION
Title says it all. Makes sure people who want a smaller binary actual get it