### PR TITLE
fix: dlopen'ing too many files causes kernel panic on M4 15.5

### DIFF
--- a/internal/lib/dump_waf_darwin.go
+++ b/internal/lib/dump_waf_darwin.go
@@ -15,43 +15,98 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"syscall"
 )
+
+const libddwafDylibName = "libddwaf.dylib"
 
 // DumpEmbeddedWAF for darwin platform.
 // DumpEmbeddedWAF creates a temporary file with the embedded WAF library content and returns the path to the file,
 // a closer function and an error. This is the only way to make all implementations of DumpEmbeddedWAF consistent
 // across all platforms.
-func DumpEmbeddedWAF() (path string, closer func() error, err error) {
-	file, err := os.CreateTemp("", "libddwaf-*.dylib")
-	if err != nil {
-		return "", nil, fmt.Errorf("error creating temp file: %w", err)
-	}
+func DumpEmbeddedWAF() (_ string, closer func() error, err error) {
+	path := filepath.Join(os.TempDir(), libddwafDylibName)
+	var fp *os.File
+	const nbAttempts = 20
 
 	defer func() {
-		if err != nil {
-			if closeErr := file.Close(); closeErr != nil {
-				err = errors.Join(err, fmt.Errorf("error closing file: %w", closeErr))
-			}
-			if rmErr := os.Remove(file.Name()); rmErr != nil {
-				err = errors.Join(err, fmt.Errorf("error removing file: %w", rmErr))
-			}
+		if err != nil && closer != nil {
+			err = errors.Join(err, closer())
 		}
 	}()
 
-	gr, err := gzip.NewReader(bytes.NewReader(libddwaf))
-	if err != nil {
-		return "", nil, fmt.Errorf("error creating gzip reader: %w", err)
+	for i := 0; i < nbAttempts; i++ {
+		if fp, err = os.Open(path); os.IsNotExist(err) {
+			// The file does not exist, try to create it.
+			if fp, err = os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_EXCL, 0o600); os.IsExist(err) {
+				// It was created by another process, try to open it again.
+				continue
+			}
+
+			if err != nil {
+				return "", nil, fmt.Errorf("error creating file %s: %w", path, err)
+			}
+
+			closer = fp.Close
+
+			// We were the one to create the file, so we can lock it.
+			if err = lock(fp); err != nil {
+				return "", nil, fmt.Errorf("error locking file %s: %w", path, err)
+			}
+
+			closer = func() error {
+				return errors.Join(unlock(fp), fp.Close())
+			}
+
+			gr, err := gzip.NewReader(bytes.NewReader(libddwaf))
+			if err != nil {
+				return "", nil, fmt.Errorf("error creating gzip reader: %w", err)
+			}
+
+			if _, err := io.Copy(fp, gr); err != nil {
+				return "", nil, fmt.Errorf("error copying gzip content to file: %w", err)
+			}
+
+			if err := gr.Close(); err != nil {
+				return "", nil, fmt.Errorf("error closing gzip reader: %w", err)
+			}
+
+			return fp.Name(), closer, nil
+		}
+
+		if err != nil {
+			return "", nil, fmt.Errorf("error opening file %s: %w", path, err)
+		}
+
+		closer = fp.Close
+
+		// The file exists, try to rlock it.
+		if err = rlock(fp); err != nil {
+			return "", nil, fmt.Errorf("error rlocking file %s: %w", path, err)
+		}
+
+		closer = func() error {
+			return errors.Join(unlock(fp), fp.Close())
+		}
+
+		return fp.Name(), closer, nil
 	}
 
-	if _, err := io.Copy(file, gr); err != nil {
-		return "", nil, fmt.Errorf("error copying gzip content to file: %w", err)
-	}
+	return "", nil, fmt.Errorf("failed to create or open file %s after %d attempts, last error: %w", path, nbAttempts, err)
+}
 
-	if err := gr.Close(); err != nil {
-		return "", nil, fmt.Errorf("error closing gzip reader: %w", err)
-	}
+// rlock places an advisory shared lock on the specified file.
+func rlock(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_SH)
+}
 
-	return file.Name(), func() error {
-		return errors.Join(file.Close(), os.Remove(file.Name()))
-	}, nil
+// lock places an advisory exclusive lock on the specified file.
+func lock(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
+}
+
+// unlock removes any advisory locks from the specified file.
+func unlock(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
 }

--- a/internal/lib/dump_waf_darwin.go
+++ b/internal/lib/dump_waf_darwin.go
@@ -39,7 +39,7 @@ func DumpEmbeddedWAF() (_ string, closer func() error, err error) {
 	for i := 0; i < nbAttempts; i++ {
 		if fp, err = os.Open(path); os.IsNotExist(err) {
 			// The file does not exist, try to create it.
-			if fp, err = os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_EXCL, 0o600); os.IsExist(err) {
+			if fp, err = os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_EXCL, 0o700); os.IsExist(err) {
 				// It was created by another process, try to open it again.
 				continue
 			}

--- a/internal/lib/dump_waf_darwin.go
+++ b/internal/lib/dump_waf_darwin.go
@@ -86,7 +86,7 @@ func DumpEmbeddedWAF() (_ string, closer func() error, err error) {
 			return "", nil, fmt.Errorf("error rlocking file %s: %w", path, err)
 		}
 
-		if fileinfo, err := fp.Stat(); err != nil && fileinfo.Size() < len(libddwaf) {
+		if fileinfo, err := fp.Stat(); err != nil && fileinfo.Size() < int64(len(libddwaf)) {
 			// The file is not written yet, so we need to unlock it and try again.
 			if err = unlock(fp); err != nil {
 				return "", nil, fmt.Errorf("error unlocking file %s: %w", path, err)

--- a/internal/lib/dump_waf_darwin.go
+++ b/internal/lib/dump_waf_darwin.go
@@ -19,14 +19,14 @@ import (
 	"syscall"
 )
 
-const libddwafDylibName = "libddwaf.dylib"
+const libddwafDylibName = "libddwaf-%s.dylib"
 
 // DumpEmbeddedWAF for darwin platform.
 // DumpEmbeddedWAF creates a temporary file with the embedded WAF library content and returns the path to the file,
 // a closer function and an error. This is the only way to make all implementations of DumpEmbeddedWAF consistent
 // across all platforms.
 func DumpEmbeddedWAF() (_ string, closer func() error, err error) {
-	path := filepath.Join(os.TempDir(), libddwafDylibName)
+	path := filepath.Join(os.TempDir(), fmt.Sprintf(libddwafDylibName, EmbeddedWAFVersion))
 	var fp *os.File
 	const nbAttempts = 20
 


### PR DESCRIPTION
Use a common name to write the `libddwaf.dylib` and then dlopen it