### PR TITLE
chore: migrate DD_K9_LIBRARY_GO_APP_PRIVATE_KEY to dd-octo-sts

### DIFF
--- a/.github/chainguard/self.github.update-ruleset.schedule.sts.yaml
+++ b/.github/chainguard/self.github.update-ruleset.schedule.sts.yaml
@@ -1,0 +1,13 @@
+# Policy for: .github/workflows/default-ruleset.yml in DataDog/go-libddwaf
+issuer: https://token.actions.githubusercontent.com
+subject: repo:DataDog/go-libddwaf:ref:refs/heads/main
+
+claim_pattern:
+  event_name: (schedule|workflow_dispatch)
+  job_workflow_ref: DataDog/go-libddwaf/\.github/workflows/default-ruleset\.yml@refs/heads/main
+  ref: refs/heads/main
+  repository: DataDog/go-libddwaf
+
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/workflows/_test_bare_metal.yml
+++ b/.github/workflows/_test_bare_metal.yml
@@ -25,6 +25,9 @@ jobs:
 
   test:
     needs: go-versions-matrix
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -49,15 +52,12 @@ jobs:
         run: sudo apt update && sudo apt install -y build-essential
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
-      - name: Generate a GitHub token
+      - name: Get GitHub token (DataDog/appsec-event-rules)
         id: generate-token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         with:
-          app-id: ${{ vars.DD_K9_LIBRARY_GO_APP_ID }}
-          private-key: ${{ secrets.DD_K9_LIBRARY_GO_APP_PRIVATE_KEY }}
-          owner: DataDog
-          repositories: appsec-event-rules
-          permission-contents: read
+          scope: DataDog/appsec-event-rules
+          policy: go-libddwaf.github.read-rules
       - name: go test
         shell: bash
         run: ./.github/workflows/ci.sh

--- a/.github/workflows/default-ruleset.yml
+++ b/.github/workflows/default-ruleset.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Update
     permissions:
+      id-token: write
       contents: write
     steps:
       - name: Checkout
@@ -21,15 +22,12 @@ jobs:
         with:
           go-version: oldstable
           cache-dependency-path: _tools/ruleset-updater/go.mod
-      - name: Generate a GitHub token (DataDog/appsec-event-rules)
+      - name: Get GitHub token (DataDog/appsec-event-rules)
         id: generate-token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         with:
-          app-id: ${{ vars.DD_K9_LIBRARY_GO_APP_ID }}
-          private-key: ${{ secrets.DD_K9_LIBRARY_GO_APP_PRIVATE_KEY }}
-          owner: DataDog
-          repositories: appsec-event-rules
-          permission-contents: read
+          scope: DataDog/appsec-event-rules
+          policy: go-libddwaf.github.read-rules
       - name: Update Default Ruleset
         id: ruleset
         run: |-
@@ -57,15 +55,13 @@ jobs:
           git fetch origin "${branch}"
         env:
           VERSION: ${{ steps.ruleset.outputs.version }}
-      - name: Generate a GitHub token (${{ github.repository_owner }}/go-libddwaf)
+      - name: Get GitHub token (DataDog/go-libddwaf)
         if: fromJson(steps.detect.outputs.mutation-happened)
         id: generate-token-pr
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         with:
-          app-id: ${{ vars.DD_K9_LIBRARY_GO_APP_ID }}
-          private-key: ${{ secrets.DD_K9_LIBRARY_GO_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: go-libddwaf
+          scope: DataDog/go-libddwaf
+          policy: self.github.update-ruleset.schedule
       # We use ghcommit to create signed commits directly using the GitHub API
       - name: Create Commit on PR Branch
         if: fromJson(steps.detect.outputs.mutation-happened)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,13 +12,14 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   bare-metal:
     name: GitHub Runner
     uses: ./.github/workflows/_test_bare_metal.yml
-    # Needs secret access so it can access a GITHUB_TOKEN to verify the builder works with the
-    # latest AppSec rules package.
-    secrets: inherit
   containerized:
     name: Containerized
     uses: ./.github/workflows/_test_containerized.yml


### PR DESCRIPTION
## Summary
- Replace `actions/create-github-app-token` with `DataDog/dd-octo-sts-action` in `default-ruleset.yml` and `_test_bare_metal.yml`
- Add self-write trust policy for the default-ruleset automation
- Eliminates dependency on `DD_K9_LIBRARY_GO_APP_PRIVATE_KEY` secret

## Changes
- `default-ruleset.yml`: 2 token steps migrated, added `id-token: write` (kept `contents: write` for `git push` branch creation)
- `_test_bare_metal.yml`: 1 token step migrated, added `id-token: write` + `contents: read`
- New policy: `self.github.update-ruleset.schedule.sts.yaml` — restricted to `main`, schedule/dispatch, `contents: write` + `pull_requests: write`

## Dependencies
- Requires DataDog/appsec-event-rules read policy to be merged first (for the `appsec-event-rules` read token)

## Test plan
- [ ] Trust Policy Validation CI check passes
- [ ] After appsec-event-rules policy merges, trigger `default-ruleset.yml` via `workflow_dispatch`
- [ ] Test workflow runs on a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Jira: APPSEC-62083