### PR TITLE
fix: prevent pinned-pointer leak on concurrent Context.Run/Close

### DIFF
--- a/context.go
+++ b/context.go
@@ -324,11 +324,17 @@ func (context *Context) Close() {
 	context.mutex.Lock()
 	defer context.mutex.Unlock()
 
-	bindings.Lib.ContextDestroy(context.cContext)
-	defer context.handle.Close() // Reduce the reference counter of the Handle.
-	context.cContext = 0         // Makes it easy to spot use-after-free/double-free issues
+	if context.cContext != 0 {
+		bindings.Lib.ContextDestroy(context.cContext)
+		defer context.handle.Close() // Reduce the reference counter of the Handle.
+		context.cContext = 0         // Makes it easy to spot use-after-free/double-free issues
+	}
 
-	context.pinner.Unpin() // The pinned data is no longer needed, explicitly release
+	// Close (not Unpin) so that any concurrent Run that is still mid-encode
+	// sees a terminal pinner and its remaining Pin calls become no-ops
+	// instead of leaking onto an already-released pinner. Run still catches
+	// the closed state via cContext == 0 above.
+	context.pinner.Close()
 }
 
 // Truncations returns the truncations that occurred while encoding address data for WAF execution.

--- a/context_race_test.go
+++ b/context_race_test.go
@@ -1,0 +1,208 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build (amd64 || arm64) && (linux || darwin) && !go1.27 && !datadog.no_waf && (cgo || appsec)
+
+package libddwaf
+
+import (
+	"runtime"
+	"sync"
+	"testing"
+
+	"github.com/DataDog/go-libddwaf/v4/timer"
+	"github.com/DataDog/go-libddwaf/v4/waferrors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestContextRunCloseRace_LeaksPinnedPointer is a standalone, self-contained
+// proof that go-libddwaf has a concurrent lifecycle race on Context.pinner
+// that leaks pinned pointers and eventually blows up in the runtime.Pinner
+// finalizer with the exact signature reported in issue #211:
+//
+//	panic: runtime error: runtime.Pinner: found leaking pinned pointer;
+//	       forgot to call Unpin()?
+//
+// Why this differs from the reproducer in #211. The reproducer in the issue
+// is sequential: ctx.Close() followed by ctx.Run(...). dd-trace-go never
+// does that — it atomically swaps the Context pointer to nil before calling
+// Close, and every Run call loads from that atomic and returns early if the
+// load returns nil. The sequential "Run-after-Close" path is therefore not
+// reachable through dd-trace-go, and the fix proposed in the issue (a
+// "closed" flag on ConcurrentPinner) is only demonstrated against that
+// unreachable path.
+//
+// The race that is reachable through dd-trace-go is concurrent, not
+// sequential. Context.Run pins persistent address data into context.pinner
+// via encodeOneAddressType *before* it acquires context.mutex and checks
+// cContext == 0 (context.go:121 vs context.go:139). Context.Close takes
+// context.mutex, then calls context.pinner.Unpin() and zeroes cContext
+// (context.go:324-331). If Close runs concurrently with a Run that already
+// entered the encoder, the encoder keeps calling Pin() on context.pinner
+// after Close's Unpin() has cleared it. Those post-Unpin pins never get
+// unpinned — Close only runs once — so they are leaked onto the pinner
+// embedded in the Context. When the Context is later collected, the
+// runtime.Pinner finalizer sees the leftover entries and panics.
+//
+// Why this is flaky, not deterministic. Whether any given iteration
+// actually lands a Pin call *between* Close's mutex acquisition and the
+// Run encoder's completion depends on goroutine scheduling, the size of
+// the persistent payload, and GC timing. Some iterations race, some
+// don't. Running the test a few times in a row reliably crashes the
+// process with the finalizer panic. A race-free implementation would
+// pass every time.
+//
+// How to exercise:
+//
+//	go test -run TestContextRunCloseRace_LeaksPinnedPointer -count=10 ./...
+//
+// Under the current v4.9.x code this aborts with the finalizer panic
+// well before 10 runs complete. With a fix that serializes Pin against
+// Close (e.g., holding context.mutex across encode, or making
+// ConcurrentPinner terminal-state-aware *and* routing the encoder's
+// Pins through that gate) the test passes every run.
+func TestContextRunCloseRace_LeaksPinnedPointer(t *testing.T) {
+	waf, _, err := newDefaultHandle(testArachniRule)
+	require.NoError(t, err)
+	require.NotNil(t, waf)
+	defer waf.Close()
+
+	// A persistent payload with several scalar leaves. Every leaf becomes
+	// a separate Pin() call on context.pinner during encoding, which widens
+	// the window where Close's Unpin() can slot in between two Pin()s.
+	persistent := map[string]any{
+		"server.request.headers.no_cookies": map[string][]string{
+			"user-agent":      {"Arachni/v1", "curl/8.0"},
+			"accept":          {"application/json", "text/html", "*/*"},
+			"accept-encoding": {"gzip", "deflate", "br"},
+			"x-forwarded-for": {"1.2.3.4", "5.6.7.8", "9.10.11.12", "13.14.15.16"},
+			"x-custom":        {"a", "b", "c", "d", "e", "f", "g", "h"},
+		},
+	}
+
+	// Run many independent contexts to amortize scheduling variance. Each
+	// context gets exactly one concurrent Run+Close pair. We do not keep a
+	// slice of the contexts — once the WaitGroup returns the only root is
+	// the pair of goroutine stacks, which are already done. The contexts
+	// become collectable and their pinner finalizers will fire during GC
+	// below. If any one of them leaked a Pin past Close.Unpin(), that
+	// finalizer panics and takes the test process with it.
+	const iterations = 4000
+	for i := 0; i < iterations; i++ {
+		ctx, err := waf.NewContext(timer.WithBudget(timer.UnlimitedBudget))
+		require.NoError(t, err)
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			<-start
+			// Enter the encoder. encodeOneAddressType pins the string and
+			// slice backing memory of `persistent` into context.pinner,
+			// one Pin() call at a time, without holding context.mutex.
+			_, _ = ctx.Run(RunAddressData{Persistent: persistent})
+		}()
+
+		go func() {
+			defer wg.Done()
+			<-start
+			// Acquires context.mutex, zeros cContext, and calls
+			// context.pinner.Unpin(). If the Run goroutine is mid-encode
+			// at this moment, all its Pin() calls that happen after this
+			// Unpin() are orphans.
+			ctx.Close()
+		}()
+
+		close(start)
+		wg.Wait()
+
+		// Help the race land: yield between iterations so the scheduler
+		// actually interleaves the two goroutines rather than running them
+		// back-to-back on the same P. This is cheap and materially
+		// improves how often the race window is entered.
+		runtime.Gosched()
+	}
+
+	// Force the finalizer goroutine to run. If any iteration left pins on
+	// a closed context.pinner, the runtime.Pinner finalizer panics here.
+	runtime.GC()
+	runtime.GC()
+	runtime.GC()
+}
+
+// TestContextRunAfterCloseReturnsErr is the sequential reproducer from
+// issue #211. dd-trace-go never reaches this ordering (it atomic-swaps the
+// Context pointer to nil before Close), but this test pins the contract
+// anyway: after Close, Run must return ErrContextClosed and must not leak
+// pinned pointers onto the now-terminal context.pinner.
+func TestContextRunAfterCloseReturnsErr(t *testing.T) {
+	waf, _, err := newDefaultHandle(testArachniRule)
+	require.NoError(t, err)
+	require.NotNil(t, waf)
+	defer waf.Close()
+
+	ctx, err := waf.NewContext(timer.WithBudget(timer.UnlimitedBudget))
+	require.NoError(t, err)
+	require.NotNil(t, ctx)
+
+	ctx.Close()
+
+	// Encoder runs, hits the terminal pinner, all Pin calls no-op, the
+	// mutex-gated cContext == 0 check returns ErrContextClosed.
+	_, err = ctx.Run(RunAddressData{
+		Persistent: map[string]any{
+			"server.request.headers.no_cookies": map[string][]string{
+				"user-agent": {"Arachni/v1"},
+			},
+		},
+	})
+	assert.ErrorIs(t, err, waferrors.ErrContextClosed)
+
+	// No pins should have survived Close. A regression here would panic
+	// inside runtime.runFinalizers.
+	ctx = nil
+	runtime.GC()
+	runtime.GC()
+}
+
+// TestContextDoubleCloseSafe covers the defensive cContext != 0 guard in
+// Context.Close. Two concurrent Close calls on the same Context must not
+// double-destroy the underlying ddwaf_context and must not double-decrement
+// the handle refcount. The terminal pinner also makes pinner.Close
+// idempotent.
+func TestContextDoubleCloseSafe(t *testing.T) {
+	waf, _, err := newDefaultHandle(testArachniRule)
+	require.NoError(t, err)
+	require.NotNil(t, waf)
+	defer waf.Close()
+
+	ctx, err := waf.NewContext(timer.WithBudget(timer.UnlimitedBudget))
+	require.NoError(t, err)
+	require.NotNil(t, ctx)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	start := make(chan struct{})
+
+	go func() {
+		defer wg.Done()
+		<-start
+		ctx.Close()
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		ctx.Close()
+	}()
+
+	close(start)
+	wg.Wait()
+
+	// Sequential third close must also be a no-op.
+	ctx.Close()
+}

--- a/internal/pin/pinner.go
+++ b/internal/pin/pinner.go
@@ -34,20 +34,43 @@ type Pinner interface {
 var _ Pinner = (*runtime.Pinner)(nil)
 
 // ConcurrentPinner is a [Pinner] that is safe for concurrent use by multiple
-// goroutines.
+// goroutines. Once [ConcurrentPinner.Close] has been called, the pinner is in
+// a terminal state and any subsequent [ConcurrentPinner.Pin] call is a no-op.
+// A closed pinner cannot be reused.
 type ConcurrentPinner struct {
 	runtime.Pinner
 	sync.Mutex
+	closed bool
 }
 
+// Pin pins v unless the pinner has already been closed, in which case it is
+// a no-op. This terminal-state behavior prevents a race where [Pin] calls
+// arriving after a concurrent [Close] would leak onto the already-released
+// pinner and trigger the runtime.Pinner finalizer panic on the next GC.
 func (p *ConcurrentPinner) Pin(v any) {
 	p.Lock()
+	defer p.Unlock()
+	if p.closed {
+		return
+	}
 	p.Pinner.Pin(v)
-	p.Unlock()
 }
 
+// Unpin unpins every currently-pinned object. It does not put the pinner
+// into the terminal state; future Pin calls are still accepted. Use [Close]
+// when the pinner is being torn down for good.
 func (p *ConcurrentPinner) Unpin() {
 	p.Lock()
+	defer p.Unlock()
 	p.Pinner.Unpin()
-	p.Unlock()
+}
+
+// Close unpins every currently-pinned object and puts the pinner into a
+// terminal state where future [Pin] calls are no-ops. A closed pinner
+// cannot be reused. Calling Close multiple times is safe.
+func (p *ConcurrentPinner) Close() {
+	p.Lock()
+	defer p.Unlock()
+	p.closed = true
+	p.Pinner.Unpin()
 }

--- a/internal/pin/pinner_test.go
+++ b/internal/pin/pinner_test.go
@@ -1,0 +1,100 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package pin
+
+import (
+	"runtime"
+	"sync"
+	"testing"
+)
+
+// TestConcurrentPinnerPinAfterCloseIsNoop asserts that once Close has put the
+// pinner into its terminal state, any subsequent Pin call is a silent no-op
+// that does not leak onto the pinner. If the no-op were missing, the pinned
+// value would survive the Close's Unpin and the runtime.Pinner finalizer
+// would panic with "found leaking pinned pointer" when the pinner is GC'd.
+func TestConcurrentPinnerPinAfterCloseIsNoop(t *testing.T) {
+	p := &ConcurrentPinner{}
+
+	payload := make([]byte, 64)
+	p.Pin(&payload[0])
+	p.Close()
+
+	later := make([]byte, 64)
+	p.Pin(&later[0]) // terminal state: no-op, does not panic
+
+	// Drop all references and verify the pinner is safely collectable. A
+	// regression that pinned after Close would surface here as a finalizer
+	// panic that kills the test process.
+	p = nil
+	runtime.GC()
+	runtime.GC()
+	runtime.GC()
+}
+
+// TestConcurrentPinnerDoubleClose guards against regressions where Close is
+// not idempotent. Closing a ConcurrentPinner twice must be safe; the second
+// call is a no-op (Unpin on an empty runtime.Pinner is fine, and closed is
+// already true).
+func TestConcurrentPinnerDoubleClose(t *testing.T) {
+	p := &ConcurrentPinner{}
+
+	payload := make([]byte, 16)
+	p.Pin(&payload[0])
+
+	p.Close()
+	p.Close() // must not panic, must not re-unpin anything
+
+	runtime.GC()
+	runtime.GC()
+}
+
+// TestConcurrentPinnerCloseRaceNoLeak is the unit-level analog of the
+// context_race_test.go integration test. Many goroutines call Pin on the
+// shared pinner while one goroutine calls Close. If the terminal-state
+// gate in Pin is missing or racy, Pin calls landing after Close.Unpin
+// leak values onto the runtime.Pinner and the finalizer panics on the
+// subsequent GC. With the gate in place this test passes cleanly under
+// -race as well.
+func TestConcurrentPinnerCloseRaceNoLeak(t *testing.T) {
+	const iterations = 2000
+	const pinnersPerIter = 8
+
+	for range iterations {
+		p := &ConcurrentPinner{}
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(pinnersPerIter + 1)
+
+		for range pinnersPerIter {
+			buf := make([]byte, 32)
+			go func(b []byte) {
+				defer wg.Done()
+				<-start
+				p.Pin(&b[0])
+			}(buf)
+		}
+
+		go func() {
+			defer wg.Done()
+			<-start
+			p.Close()
+		}()
+
+		close(start)
+		wg.Wait()
+
+		// Encourage scheduler interleaving before the next iteration.
+		runtime.Gosched()
+	}
+
+	// Force the finalizer goroutine to run. Any pinner that ended up with
+	// post-Close leaked values would panic here.
+	runtime.GC()
+	runtime.GC()
+	runtime.GC()
+}


### PR DESCRIPTION
## Summary

- Fixes #211. `Context.Run` pins persistent address data into `context.pinner` outside the mutex that `Context.Close` uses when calling `Unpin()`. Under concurrent load, Close can Unpin between two of Run's Pin calls, leaving the later pins orphaned on the pinner. On GC, the `runtime.Pinner` finalizer panics with `runtime.Pinner: found leaking pinned pointer`.
- Adds a terminal-state bit to `internal/pin.ConcurrentPinner`. Post-`Close` `Pin` calls become no-ops; `Context.Close` now calls `pinner.Close()` instead of `Unpin()` and guards the C teardown with `cContext != 0` so double-close is safe.
- Memory safety is preserved because `Run` still checks `cContext == 0` under `context.mutex`; a WAFObject that was only no-op-pinned never reaches `ddwaf_run`.

## Why the fix sits in `ConcurrentPinner`, not in `Context.Run`

The narrower alternative — hold `context.mutex` across the encoder in `Run` — is blocked by a re-entrant lock inside `encodeOneAddressType` (truncations merge). Adding a terminal state to the pinner is ~15 LoC, does not change any lock ordering, and closes the exact race window. The full option space (widen mutex, RWMutex, WaitGroup, fix-callers) was reviewed by the Planner/Architect/Critic consensus before implementation.

## Note on the reproducer in the issue

The sequential reproducer in #211 (`ctx.Close(); ctx.Run(...)`) is not reachable from dd-trace-go — dd-trace-go atomically `SwapContext(nil)` before `Close`, so `Run` sees `nil` and exits before touching libddwaf. The reachable path is concurrent: goroutine A enters `Run` and starts encoding, goroutine B calls `Close` mid-encode. The new `context_race_test.go` exercises that concurrent pattern and reproduces the exact production panic 5/5 runs on the unfixed code.

## Test plan

- [x] `go test -run TestContextRunCloseRace_LeaksPinnedPointer -count=20 .` — passes 20/20 after the fix (was 0/5 before).
- [x] `go test -race ./...` — full module green.
- [x] `go vet ./...` — clean.
- [x] New unit tests in `internal/pin/pinner_test.go`: pin-after-close no-op, double-close idempotency, 2000-iteration concurrent pin-vs-close stress — all pass under `-race`.
- [x] New integration tests in `context_race_test.go`: `TestContextRunAfterCloseReturnsErr` (the issue's sequential reproducer, now with no leak) and `TestContextDoubleCloseSafe` (two concurrent `Close` calls).
- [ ] Manual smoke against a staging dd-trace-go AppSec deployment under traffic.

## Known follow-up (out of scope)

`Handle.NewContext` leaks `cContext` and the handle refcount when `timer.NewTreeTimer` fails. Pre-existing; already noted in the issue's "Misc. things" section.