### PR TITLE
fix(ci): resolve Test workflow startup_failure on PR branches

### DIFF
--- a/.github/workflows/_test_bare_metal.yml
+++ b/.github/workflows/_test_bare_metal.yml
@@ -25,9 +25,6 @@ jobs:
 
   test:
     needs: go-versions-matrix
-    permissions:
-      id-token: write
-      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -53,6 +50,7 @@ jobs:
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
       - name: Get GitHub token (DataDog/appsec-event-rules)
+        if: github.event_name != 'pull_request'
         id: generate-token
         uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         with:
@@ -65,4 +63,4 @@ jobs:
           DD_APPSEC_WAF_LOG_LEVEL: ${{ matrix.waf-log-level }}
           # We need a GITHUB_TOKEN in order to access the latest release of the AppSec rules from
           # the DataDog/appsec-rules repository.
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token || github.token }}

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -1,0 +1,35 @@
+name: Test
+on:
+  pull_request: # on pull requests touching appsec files
+
+permissions:
+  contents: read
+
+jobs:
+  bare-metal:
+    name: GitHub Runner
+    uses: ./.github/workflows/_test_bare_metal.yml
+  containerized:
+    name: Containerized
+    uses: ./.github/workflows/_test_containerized.yml
+
+  # Smoke tests are intentionally excluded from pull_request runs.
+  # The cross-repo reusable workflow in DataDog/dd-trace-go requests
+  # `id-token: write`, but GitHub only grants `id-token: none` to these
+  # PR runs, which causes a startup_failure before any job can start.
+  done:
+    name: Done
+    runs-on: ubuntu-latest
+    needs:
+      - bare-metal
+      - containerized
+    if: '!cancelled()'
+    steps:
+      - name: Done
+        if: needs.bare-metal.result == 'success' && needs.containerized.result == 'success'
+        run: echo "Done!"
+      - name: Done
+        if: needs.bare-metal.result != 'success' || needs.containerized.result != 'success'
+        run: |-
+          echo "Failed!"
+          exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,6 @@ on:
         default: 'main'
   schedule: # nightly
     - cron: "0 0 * * *"
-  pull_request: # on pull requests touching appsec files
   push: # on push to the main branch
     branches:
       - main


### PR DESCRIPTION
## Summary
- move pull_request runs into a PR-only Test workflow that keeps the existing local bare-metal and containerized coverage
- keep cross-repo smoke tests in the non-PR Test workflow because GitHub now grants these PR runs only `id-token: none`, which makes the reusable smoke-tests workflow fail at startup
- preserve the existing `Test` workflow name/check shape while removing the startup failure path on PRs

## Testing
- validated the updated workflow YAML with PyYAML
- verified no YAML LSP diagnostics on `.github/workflows/test.yml` and `.github/workflows/test-pr.yml`