### PR TITLE
chore: add Datadog Code Coverage upload, remove CodeCov

### DIFF
--- a/.github/workflows/_test_bare_metal.yml
+++ b/.github/workflows/_test_bare_metal.yml
@@ -67,14 +67,14 @@ jobs:
           # the DataDog/appsec-rules repository.
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: Generate coverage report
-        if: matrix.runs-on == 'ubuntu-24.04' && matrix.go-version == 'stable' && !matrix.waf-log-level
+        if: matrix.runs-on == 'ubuntu-24.04' && matrix.go-version == 'stable'
         shell: bash
         run: go test -tags ci,appsec -coverprofile=coverage.out -args -waf-build-tags="appsec,linux,amd64" -waf-supported="true" ./...
         env:
           DD_APPSEC_WAF_TIMEOUT: 10m
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: Upload coverage to Datadog
-        if: matrix.runs-on == 'ubuntu-24.04' && matrix.go-version == 'stable' && !matrix.waf-log-level
+        if: matrix.runs-on == 'ubuntu-24.04' && matrix.go-version == 'stable'
         env:
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
         run: npx --yes @datadog/datadog-ci coverage upload --service go-libddwaf coverage.out

--- a/.github/workflows/_test_bare_metal.yml
+++ b/.github/workflows/_test_bare_metal.yml
@@ -66,3 +66,15 @@ jobs:
           # We need a GITHUB_TOKEN in order to access the latest release of the AppSec rules from
           # the DataDog/appsec-rules repository.
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+      - name: Generate coverage report
+        if: matrix.runs-on == 'ubuntu-24.04' && matrix.go-version == 'stable'
+        shell: bash
+        run: go test -tags ci,appsec -coverprofile=coverage.out ./...
+        env:
+          DD_APPSEC_WAF_TIMEOUT: 10m
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+      - name: Upload coverage to Datadog
+        if: matrix.runs-on == 'ubuntu-24.04' && matrix.go-version == 'stable'
+        env:
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+        run: npx --yes @datadog/datadog-ci coverage upload --service go-libddwaf coverage.out

--- a/.github/workflows/_test_bare_metal.yml
+++ b/.github/workflows/_test_bare_metal.yml
@@ -67,14 +67,14 @@ jobs:
           # the DataDog/appsec-rules repository.
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: Generate coverage report
-        if: matrix.runs-on == 'ubuntu-24.04' && matrix.go-version == 'stable'
+        if: matrix.runs-on == 'ubuntu-24.04' && matrix.go-version == 'stable' && !matrix.waf-log-level
         shell: bash
-        run: go test -tags ci,appsec -coverprofile=coverage.out ./...
+        run: go test -tags ci,appsec -coverprofile=coverage.out -args -waf-build-tags="appsec,linux,amd64" -waf-supported="true" ./...
         env:
           DD_APPSEC_WAF_TIMEOUT: 10m
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: Upload coverage to Datadog
-        if: matrix.runs-on == 'ubuntu-24.04' && matrix.go-version == 'stable'
+        if: matrix.runs-on == 'ubuntu-24.04' && matrix.go-version == 'stable' && !matrix.waf-log-level
         env:
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
         run: npx --yes @datadog/datadog-ci coverage upload --service go-libddwaf coverage.out

--- a/.github/workflows/_test_bare_metal.yml
+++ b/.github/workflows/_test_bare_metal.yml
@@ -66,15 +66,7 @@ jobs:
           # We need a GITHUB_TOKEN in order to access the latest release of the AppSec rules from
           # the DataDog/appsec-rules repository.
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-      - name: Generate coverage report
-        if: matrix.runs-on == 'ubuntu-24.04' && matrix.go-version == 'stable'
-        shell: bash
-        run: go test -tags ci,appsec -coverprofile=coverage.out -args -waf-build-tags="appsec,linux,amd64" -waf-supported="true" ./...
-        env:
-          DD_APPSEC_WAF_TIMEOUT: 10m
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-      - name: Upload coverage to Datadog
-        if: matrix.runs-on == 'ubuntu-24.04' && matrix.go-version == 'stable'
-        env:
+          # ci.sh generates a coverage profile and uploads it to Datadog Code Coverage when
+          # COVERAGE is set. Gate it to a single matrix entry to avoid duplicate uploads.
+          COVERAGE: ${{ (matrix.runs-on == 'ubuntu-24.04' && matrix.go-version == 'stable') && 'true' || '' }}
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
-        run: npx --yes @datadog/datadog-ci coverage upload --service go-libddwaf coverage.out

--- a/.github/workflows/ci.sh
+++ b/.github/workflows/ci.sh
@@ -32,8 +32,14 @@ run() {
     test_tags="$2,$GOOS,$GOARCH"
     cgo=$($(contains "$2" cgo) && echo 1 || echo 0)
 
+    # COVERAGE is set by the CI on a single matrix entry to avoid duplicate uploads.
+    cover=""
+    if [ "${COVERAGE:-}" = "true" ] && [ "$2" = "appsec" ]; then
+        cover="-coverprofile=coverage.out"
+    fi
+
     echo "Running matrix $test_tags where the WAF is enablement is ${waf_enabled}..."
-    env CGO_ENABLED="$cgo" go test -shuffle=on -tags="$tags" -args -waf-build-tags="$test_tags" -waf-supported="$waf_enabled" ./...
+    env CGO_ENABLED="$cgo" go test $cover -shuffle=on -tags="$tags" -args -waf-build-tags="$test_tags" -waf-supported="$waf_enabled" ./...
 
     if ! $waf_enabled; then
         return
@@ -60,3 +66,14 @@ fi
 
 run "$WAF_ENABLED" cgo                   # WAF enabled (but not on windows)
 run false datadog.no_waf,cgo             # WAF manually disabled and CGO enabled
+
+# Only the matrix entry that set COVERAGE=true produces coverage.out, so this uploads once.
+# datadog-ci reads either DATADOG_API_KEY or DD_API_KEY; both are absent on fork pull
+# requests, where the upload is skipped instead of failing the job.
+if [ "${COVERAGE:-}" = "true" ] && [ -f coverage.out ]; then
+    if [ -z "${DATADOG_API_KEY:-}" ] && [ -z "${DD_API_KEY:-}" ]; then
+        echo "No Datadog API key (DATADOG_API_KEY/DD_API_KEY) is set; skipping coverage upload"
+    else
+        DD_SERVICE=go-libddwaf npx --yes @datadog/datadog-ci coverage upload coverage.out
+    fi
+fi


### PR DESCRIPTION
Onboard to Datadog Code Coverage and remove CodeCov upload.

## Changes

- Added a "Generate coverage report" step in `_test_bare_metal.yml` that runs `go test -coverprofile=coverage.out` (gated to ubuntu-24.04 + stable Go to avoid duplicate uploads across the matrix).
- Added an "Upload coverage to Datadog" step using `@datadog/datadog-ci` right after, reading `DATADOG_API_KEY` from secrets.
- No CodeCov steps were present in this repository, so no removal was necessary.