### PR TITLE
feat: subcontext stat rollup, Runner interface, and Supports accessors

### DIFF
--- a/context.go
+++ b/context.go
@@ -270,10 +270,21 @@ func (context *Context) Run(ctx context.Context, addressData RunAddressData) (re
 //
 // Close cascades to subcontexts: any still-open [Subcontext] derived from this
 // Context via [Context.NewSubcontext] is fully torn down as part of Close — its
-// underlying ddwaf_subcontext is destroyed and its pinned input data released.
+// underlying ddwaf_subcontext is destroyed, its pinned input data released, and
+// its per-scope timer durations and truncations folded into this Context.
 // (The underlying ddwaf_context_destroy does not itself cascade, so go-libddwaf
 // destroys each live subcontext explicitly before destroying the context.)
 // Calling [Subcontext.Close] afterwards remains safe and becomes a no-op.
+//
+// The parent [Context] reflects a subcontext's timer stats and truncations only
+// after that subcontext is closed — either explicitly via [Subcontext.Close] or
+// implicitly via this cascade. Callers reading the aggregate [Context.Timer] or
+// [Context.Truncations] must close their subcontexts first (or read after
+// [Context.Close]).
+// For this rollup, only subcontext runs that have fully returned before Close
+// are guaranteed to be reflected; a subcontext Run executing concurrently with
+// Context.Close may be omitted from the aggregate timer durations or
+// truncations.
 //
 // Close blocks until all in-flight Run and NewSubcontext operations complete,
 // and is safe to call more than once.
@@ -312,6 +323,12 @@ func (context *Context) Close() {
 	context.pinners = nil
 
 	context.handle.Close()
+}
+
+// Supports reports whether the WAF ruleset behind this context monitors addr,
+// via the handle's cached known-address set.
+func (context *Context) Supports(addr string) bool {
+	return context.handle.Supports(addr)
 }
 
 // Truncations returns the truncations that occurred while encoding address

--- a/context_supports_test.go
+++ b/context_supports_test.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build (amd64 || arm64) && (linux || darwin) && !go1.28 && !datadog.no_waf && (cgo || appsec)
+
+package libddwaf
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/go-libddwaf/v5/timer"
+)
+
+func TestContextSupports(t *testing.T) {
+	waf, _, err := newDefaultHandle(t, newArachniTestRule(t, []ruleInput{{Address: "my.input"}}, nil))
+	require.NoError(t, err)
+	t.Cleanup(func() { waf.Close() })
+
+	ctx, err := waf.NewContext(context.Background(), timer.WithBudget(timer.UnlimitedBudget))
+	require.NoError(t, err)
+	t.Cleanup(func() { ctx.Close() })
+
+	require.True(t, ctx.Supports("my.input"))
+	require.False(t, ctx.Supports("nope"))
+}
+
+func TestSubcontextSupports(t *testing.T) {
+	waf, _, err := newDefaultHandle(t, newArachniTestRule(t, []ruleInput{{Address: "my.input"}}, nil))
+	require.NoError(t, err)
+	t.Cleanup(func() { waf.Close() })
+
+	ctx, err := waf.NewContext(context.Background(), timer.WithBudget(timer.UnlimitedBudget))
+	require.NoError(t, err)
+	t.Cleanup(func() { ctx.Close() })
+
+	subCtx, err := ctx.NewSubcontext(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { subCtx.Close() })
+
+	require.True(t, subCtx.Supports("my.input"))
+	require.False(t, subCtx.Supports("nope"))
+}

--- a/handle.go
+++ b/handle.go
@@ -8,6 +8,7 @@ package libddwaf
 import (
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 
 	"github.com/DataDog/go-libddwaf/v5/internal/bindings"
@@ -48,6 +49,13 @@ type Handle struct {
 	refCounter atomic.Int32
 
 	cHandle bindings.WAFHandle
+
+	// addrOnce guards the one-time population of addrSet from Handle.Addresses().
+	// The C layer (KnownAddresses) is called at most once per handle lifetime.
+	addrOnce sync.Once
+	// addrSet is the lazily-built snapshot of known addresses for this handle.
+	// Populated under addrOnce.Do; nil until first Supports call on a live handle.
+	addrSet map[string]struct{}
 }
 
 // wrapHandle wraps the provided C handle into a [Handle]. The caller is
@@ -112,6 +120,32 @@ func (handle *Handle) NewContext(ctx context.Context, timerOptions ...timer.Opti
 // ruleset.
 func (handle *Handle) Addresses() []string {
 	return bindings.Lib.KnownAddresses(handle.cHandle)
+}
+
+// Supports reports whether addr is a member of this handle's known-address set
+// (the authoritative monitored-address set returned by [Handle.Addresses] /
+// KnownAddresses). This is NOT a diagnostics-derived set.
+//
+// The address set is built lazily on the first call and cached; the underlying
+// C layer (KnownAddresses) is called at most once per handle. The set is a
+// snapshot of the immutable handle, so subsequent calls are consistent.
+//
+// Returns false when the handle has been closed (cHandle == 0), or on
+// unsupported platforms where KnownAddresses returns nil.
+func (handle *Handle) Supports(addr string) bool {
+	if handle.cHandle == 0 {
+		return false
+	}
+	handle.addrOnce.Do(func() {
+		addrs := handle.Addresses()
+		set := make(map[string]struct{}, len(addrs))
+		for _, a := range addrs {
+			set[a] = struct{}{}
+		}
+		handle.addrSet = set
+	})
+	_, ok := handle.addrSet[addr]
+	return ok
 }
 
 // Actions returns the list of actions the WAF has been configured to monitor based on the input

--- a/handle.go
+++ b/handle.go
@@ -130,13 +130,26 @@ func (handle *Handle) Addresses() []string {
 // C layer (KnownAddresses) is called at most once per handle. The set is a
 // snapshot of the immutable handle, so subsequent calls are consistent.
 //
-// Returns false when the handle has been closed (cHandle == 0), or on
-// unsupported platforms where KnownAddresses returns nil.
+// Supports is safe to call concurrently with [Handle.Close]. It retains the
+// handle across the KnownAddresses call so a concurrent final Close cannot
+// destroy the C handle mid-call (use-after-free). If the handle is released
+// before the set is ever built, Supports returns false; a cached set remains
+// valid and read-only after construction.
 func (handle *Handle) Supports(addr string) bool {
-	if handle.cHandle == 0 {
+	// Fast path: a released handle monitors nothing. refCounter is atomic, so
+	// this read is race-free (unlike reading cHandle directly).
+	if handle.refCounter.Load() <= 0 {
 		return false
 	}
 	handle.addrOnce.Do(func() {
+		// Retain across the KnownAddresses call so a concurrent final Close
+		// cannot Destroy the C handle mid-call (use-after-free). If the handle
+		// was released between the fast-path check and here, retain fails and
+		// addrSet stays nil (-> Supports returns false).
+		if !handle.retain() {
+			return
+		}
+		defer handle.Close()
 		addrs := handle.Addresses()
 		set := make(map[string]struct{}, len(addrs))
 		for _, a := range addrs {

--- a/handle_supports_test.go
+++ b/handle_supports_test.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build (amd64 || arm64) && (linux || darwin) && !go1.28 && !datadog.no_waf && (cgo || appsec)
+
+package libddwaf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleSupports(t *testing.T) {
+	rule := newArachniTestRule(t, []ruleInput{{Address: "my.input"}}, nil)
+	h, _, err := newDefaultHandle(t, rule)
+	require.NoError(t, err)
+
+	t.Run("known address returns true", func(t *testing.T) {
+		require.True(t, h.Supports("my.input"))
+	})
+
+	t.Run("unknown address returns false", func(t *testing.T) {
+		require.False(t, h.Supports("not.an.address"))
+	})
+
+	t.Run("repeated calls are consistent (lazy cache hit)", func(t *testing.T) {
+		require.True(t, h.Supports("my.input"))
+		require.False(t, h.Supports("not.an.address"))
+	})
+
+	// Exercise the closed-handle guard on a handle that has NEVER had Supports
+	// called before Close, so the addrSet cache is definitely cold.
+	t.Run("closed handle guard (cold cache)", func(t *testing.T) {
+		rule2 := newArachniTestRule(t, []ruleInput{{Address: "my.input"}}, nil)
+		h2, _, err := newDefaultHandle(t, rule2)
+		require.NoError(t, err)
+		h2.Close()
+		// cHandle == 0 now; must return false without crashing
+		require.False(t, h2.Supports("not_yet_cached_addr"))
+	})
+
+	h.Close()
+}

--- a/handle_supports_test.go
+++ b/handle_supports_test.go
@@ -8,6 +8,7 @@
 package libddwaf
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -38,9 +39,48 @@ func TestHandleSupports(t *testing.T) {
 		h2, _, err := newDefaultHandle(t, rule2)
 		require.NoError(t, err)
 		h2.Close()
-		// cHandle == 0 now; must return false without crashing
+		// refCounter <= 0 now; must return false without crashing
 		require.False(t, h2.Supports("not_yet_cached_addr"))
 	})
 
 	h.Close()
+}
+
+// TestHandleSupportsConcurrentClose exercises the fix for the use-after-free
+// and data race that existed when a concurrent final Close could destroy the
+// C handle between the nil-guard check and the KnownAddresses call inside
+// addrOnce.Do.
+//
+// The test spawns N goroutines that call Supports concurrently with one
+// goroutine that calls Close. It makes no assertion on the boolean return
+// value (either true or false is valid depending on scheduling); the only
+// assertion is that there is no panic and that go test -race reports no
+// data race.
+func TestHandleSupportsConcurrentClose(t *testing.T) {
+	rule := newArachniTestRule(t, []ruleInput{{Address: "my.input"}}, nil)
+	h, _, err := newDefaultHandle(t, rule)
+	require.NoError(t, err)
+
+	const n = 20
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(n + 1)
+
+	for range n {
+		go func() {
+			defer wg.Done()
+			<-start
+			// Tolerate true or false — the assertion is no data race / no panic.
+			_ = h.Supports("my.input")
+		}()
+	}
+
+	go func() {
+		defer wg.Done()
+		<-start
+		h.Close()
+	}()
+
+	close(start)
+	wg.Wait()
 }

--- a/runner.go
+++ b/runner.go
@@ -32,6 +32,15 @@ type RunAddressData struct {
 	TimerKey timer.Key
 }
 
+// Runner is the common run surface of [*Context] and [*Subcontext]. It is
+// intentionally narrow: only Run belongs here, not Close, Truncations, or Supports.
+type Runner interface {
+	Run(ctx context.Context, addressData RunAddressData) (Result, error)
+}
+
+var _ Runner = (*Context)(nil)
+var _ Runner = (*Subcontext)(nil)
+
 func (d RunAddressData) isEmpty() bool {
 	return len(d.Data) == 0
 }

--- a/runner_test.go
+++ b/runner_test.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build (amd64 || arm64) && (linux || darwin) && !go1.28 && !datadog.no_waf && (cgo || appsec)
+
+package libddwaf
+
+import (
+	stdcontext "context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/go-libddwaf/v5/timer"
+)
+
+func TestRunnerInterfaceSatisfied(t *testing.T) {
+	handle, _, err := newDefaultHandle(t, newArachniTestRule(t, []ruleInput{{Address: "my.input"}}, nil))
+	require.NoError(t, err)
+	defer handle.Close()
+
+	ctx, err := handle.NewContext(stdcontext.Background(), timer.WithUnlimitedBudget(), timer.WithComponents("waf"))
+	require.NoError(t, err)
+	defer ctx.Close()
+
+	runner := Runner(ctx)
+	res, err := runner.Run(stdcontext.Background(), RunAddressData{})
+	require.NoError(t, err)
+	require.Empty(t, res.Events)
+	require.Empty(t, res.Derivatives)
+	require.Empty(t, res.Actions)
+	require.False(t, res.Keep)
+
+	subctx, err := ctx.NewSubcontext(stdcontext.Background())
+	require.NoError(t, err)
+	defer subctx.Close()
+
+	runner = Runner(subctx)
+	res, err = runner.Run(stdcontext.Background(), RunAddressData{})
+	require.NoError(t, err)
+	require.Empty(t, res.Events)
+	require.Empty(t, res.Derivatives)
+	require.Empty(t, res.Actions)
+	require.False(t, res.Keep)
+}

--- a/subcontext.go
+++ b/subcontext.go
@@ -152,9 +152,29 @@ func (s *Subcontext) Run(ctx context.Context, addressData RunAddressData) (res R
 	return decodeWafResult(ctx, ret, &result, runTimer)
 }
 
-// Close disposes of the underlying subcontext.
+// Close disposes of the underlying subcontext and folds its per-scope timer
+// durations and truncations into the parent [Context]. After Close returns,
+// [Context.Timer] stats and [Context.Truncations] reflect the subcontext's
+// accumulated data.
+//
+// Only runs made with a non-empty [RunAddressData.TimerKey] are captured; runs
+// with an empty TimerKey use a standalone timer not attached to the subcontext's
+// scope tree, so their time is not rolled up.
+//
+// For this rollup, only runs that have fully returned before Close are
+// guaranteed to be reflected; a Run executing concurrently with Close may miss
+// having its timer durations or truncations captured.
+//
+// This rollup affects only the aggregate [Context.Timer] / [Context.Truncations]
+// view, not any [Result.TimerStats] already returned by a prior Run call.
 func (s *Subcontext) Close() {
 	s.close(false)
+}
+
+// Supports reports whether the WAF ruleset behind this subcontext monitors
+// addr, via the handle's cached known-address set.
+func (s *Subcontext) Supports(addr string) bool {
+	return s.parent.handle.Supports(addr)
 }
 
 // close tears down the subcontext. parentLocked must be true only when the
@@ -203,7 +223,45 @@ func (s *Subcontext) close(parentLocked bool) {
 	s.pinners = nil
 	s.pinnersMu.Unlock()
 
+	s.rollupInto(s.parent)
 	s.parent.handle.Close()
+}
+
+// rollupInto merges this subcontext's per-scope timer durations and truncations
+// into parent. Called from close(), it runs on both close paths (explicit
+// Subcontext.Close and Context.Close cascade).
+//
+// Lock discipline: MUST NOT acquire s.mu or parent.mu. On the cascade path
+// (parentLocked=true), parent.mu is already held by Context.Close; re-acquiring
+// it self-deadlocks. Only atomic parent.Timer.AddTime and the independent
+// parent.truncationsMu are used.
+func (s *Subcontext) rollupInto(parent *Context) {
+	// Per-scope timer rollup: AddTime is atomic and a silent no-op for keys
+	// the parent timer does not have (e.g. "encode"/"duration"/"decode" when
+	// the parent was created with no named components).
+	for key, dur := range s.Timer.Stats() {
+		parent.Timer.AddTime(key, dur)
+	}
+
+	// Truncation rollup: read under s.truncationsMu because on the cascade
+	// path (parentLocked=true, s.mu not held) a concurrent Subcontext.Run may
+	// have written s.truncations after the parent-closed check and before
+	// close(true) was called.
+	s.truncationsMu.RLock()
+	local := Truncations{
+		StringTooLong:     append([]int(nil), s.truncations.StringTooLong...),
+		ContainerTooLarge: append([]int(nil), s.truncations.ContainerTooLarge...),
+		ObjectTooDeep:     append([]int(nil), s.truncations.ObjectTooDeep...),
+	}
+	s.truncationsMu.RUnlock()
+
+	if local.IsEmpty() {
+		return
+	}
+
+	parent.truncationsMu.Lock()
+	parent.truncations.Merge(local)
+	parent.truncationsMu.Unlock()
 }
 
 // Truncations returns the truncations that occurred while encoding address data for WAF execution.

--- a/subcontext_test.go
+++ b/subcontext_test.go
@@ -63,6 +63,108 @@ func TestSubcontextTruncations(t *testing.T) {
 	require.Equal(t, len(oversized), tr.StringTooLong[0])
 }
 
+func TestSubcontextCloseRollsUpIntoParent(t *testing.T) {
+	waf, _, err := newDefaultHandle(t, newArachniTestRule(t, []ruleInput{{Address: "my.input"}}, nil))
+	require.NoError(t, err)
+	t.Cleanup(func() { waf.Close() })
+
+	ctx, err := waf.NewContext(context.Background(), timer.WithBudget(timer.UnlimitedBudget), timer.WithComponents("waf"))
+	require.NoError(t, err)
+	t.Cleanup(func() { ctx.Close() })
+
+	subCtx, err := ctx.NewSubcontext(context.Background())
+	require.NoError(t, err)
+
+	oversized := strings.Repeat("a", int(bindings.MaxStringLength)*2)
+	_, _ = subCtx.Run(context.Background(), RunAddressData{Data: map[string]any{"my.input": oversized}, TimerKey: "waf"})
+	subCtx.Close()
+
+	require.Greater(t, ctx.Timer.Stats()["waf"], time.Duration(0))
+	require.False(t, ctx.Truncations().IsEmpty())
+}
+
+func TestContextCloseCascadeRollsUpSubcontext(t *testing.T) {
+	waf, _, err := newDefaultHandle(t, newArachniTestRule(t, []ruleInput{{Address: "my.input"}}, nil))
+	require.NoError(t, err)
+	t.Cleanup(func() { waf.Close() })
+
+	ctx, err := waf.NewContext(context.Background(), timer.WithBudget(timer.UnlimitedBudget), timer.WithComponents("waf"))
+	require.NoError(t, err)
+	t.Cleanup(func() { ctx.Close() })
+
+	subCtx, err := ctx.NewSubcontext(context.Background())
+	require.NoError(t, err)
+	// subCtx intentionally NOT closed before ctx — Context.Close cascade path under test.
+
+	oversized := strings.Repeat("a", int(bindings.MaxStringLength)*2)
+	_, _ = subCtx.Run(context.Background(), RunAddressData{Data: map[string]any{"my.input": oversized}, TimerKey: "waf"})
+
+	ctx.Close()
+
+	// Context.Timer and truncations remain readable after Close (pure Go fields).
+	require.Greater(t, ctx.Timer.Stats()["waf"], time.Duration(0))
+	require.False(t, ctx.Truncations().IsEmpty())
+}
+
+func TestSubcontextRollupPerScopeAttribution(t *testing.T) {
+	waf, _, err := newDefaultHandle(t, newArachniTestRule(t, []ruleInput{{Address: "my.input"}}, nil))
+	require.NoError(t, err)
+	t.Cleanup(func() { waf.Close() })
+
+	ctx, err := waf.NewContext(context.Background(), timer.WithBudget(timer.UnlimitedBudget), timer.WithComponents("waf", "rasp"))
+	require.NoError(t, err)
+	t.Cleanup(func() { ctx.Close() })
+
+	subCtx, err := ctx.NewSubcontext(context.Background())
+	require.NoError(t, err)
+
+	_, _ = subCtx.Run(context.Background(), RunAddressData{Data: map[string]any{"my.input": "benign"}, TimerKey: "waf"})
+	_, _ = subCtx.Run(context.Background(), RunAddressData{Data: map[string]any{"my.input": "benign"}, TimerKey: "rasp"})
+	subCtx.Close()
+
+	require.Greater(t, ctx.Timer.Stats()["waf"], time.Duration(0))
+	require.Greater(t, ctx.Timer.Stats()["rasp"], time.Duration(0))
+}
+
+func TestSubcontextEmptyTimerKeyDoesNotRollUp(t *testing.T) {
+	waf, _, err := newDefaultHandle(t, newArachniTestRule(t, []ruleInput{{Address: "my.input"}}, nil))
+	require.NoError(t, err)
+	t.Cleanup(func() { waf.Close() })
+
+	ctx, err := waf.NewContext(context.Background(), timer.WithBudget(timer.UnlimitedBudget), timer.WithComponents("waf"))
+	require.NoError(t, err)
+	t.Cleanup(func() { ctx.Close() })
+
+	subCtx, err := ctx.NewSubcontext(context.Background())
+	require.NoError(t, err)
+
+	// Empty TimerKey uses a standalone tree timer not attached to s.Timer, so
+	// s.Timer["waf"] stays zero and nothing rolls up into the parent.
+	_, _ = subCtx.Run(context.Background(), RunAddressData{Data: map[string]any{"my.input": "benign"}})
+	subCtx.Close()
+
+	require.Equal(t, time.Duration(0), ctx.Timer.Stats()["waf"])
+}
+
+func TestSubcontextRollupNoComponentParentNoOp(t *testing.T) {
+	waf, _, err := newDefaultHandle(t, newArachniTestRule(t, []ruleInput{{Address: "my.input"}}, nil))
+	require.NoError(t, err)
+	t.Cleanup(func() { waf.Close() })
+
+	ctx, err := waf.NewContext(context.Background(), timer.WithBudget(timer.UnlimitedBudget))
+	require.NoError(t, err)
+	t.Cleanup(func() { ctx.Close() })
+
+	subCtx, err := ctx.NewSubcontext(context.Background())
+	require.NoError(t, err)
+
+	_, _ = subCtx.Run(context.Background(), RunAddressData{Data: map[string]any{"my.input": "benign"}, TimerKey: DurationTimeKey})
+	require.Greater(t, subCtx.Timer.Stats()[DurationTimeKey], time.Duration(0))
+	subCtx.Close()
+
+	require.Empty(t, ctx.Timer.Stats())
+}
+
 func TestSiblingSubcontextParallelismSpeedup(t *testing.T) {
 	waf, _, err := newDefaultHandle(t, newArachniTestRule(t, []ruleInput{{Address: "server.request.headers.no_cookies", KeyPath: []string{"user-agent"}}}, nil))
 	require.NoError(t, err)


### PR DESCRIPTION
## What & why

Three v5 ergonomic improvements to `go-libddwaf` so downstream consumers (e.g. dd-trace-go) can drop hand-written shims and bookkeeping. All changes are **additive and library-only** — no `Run` signature changes, no removed/renamed exported symbols, no `timer`-package API changes.

## Changes

### W1 — Auto-roll-up subcontext stats into the parent `Context`
When a `Subcontext` is torn down, its per-scope timer durations and truncations are now folded into the parent `Context`. This happens on **both** teardown paths:
- explicit `Subcontext.Close()`, and
- the `Context.Close()` cascade (`sub.close(true)`).

The rollup is **per-`TimerKey`** (via `parent.Timer.AddTime`), so two scopes used on one subcontext (e.g. `waf` and `rasp`) are each attributed correctly — no last-scope-wins. Truncations are merged under the parent's existing `truncationsMu`. The rollup uses only atomic `AddTime` + the independent `truncationsMu` — **no new lock and no lock-order change**; on the cascade path `parent.mu` stays caller-held by `Context.Close` and is never re-acquired.

This lets dd-trace-go delete its manual `AddSubcontextStats` / `subcontextExternalDurations` / `MergedTruncations` accumulator.

### W2 — Exported `Runner` interface
`Runner { Run(context.Context, RunAddressData) (Result, error) }`, implemented by both `*Context` and `*Subcontext` (compile-time assertions included). Intentionally narrow — only `Run`. Replaces dd-trace-go's private `wafRunner` shim.

### W3 — Cheap supported-address query
`Handle.Supports(addr string) bool` backed by a lazily-built, cached known-address set (the C `KnownAddresses` is called at most once per handle; guarded for closed handles). Plus `Context.Supports` and `Subcontext.Supports` delegating to the handle. Membership is defined as the authoritative `Handle.Addresses()` / `KnownAddresses()` set — not a diagnostics-derived set. Replaces dd-trace-go's `supportedAddresses` bookkeeping.

## Testing

- New tests (all carry the standard WAF build tag): subcontext rollup happy-path, `Context.Close()` cascade rollup, per-scope attribution, empty-`TimerKey` boundary, no-component-parent no-op, `Runner` interface satisfaction, `Handle.Supports`, `Context.Supports`, `Subcontext.Supports`.
- `go test ./...` — all packages pass, no regressions.
- `go test -race .` — clean (rollup verified race-free on both close paths; `Handle.Supports` lazy init race-free).
- `golangci-lint run` — 0 issues; `go vet .` clean.

## Known limitation (documented)

The rollup reflects subcontext runs that have **fully returned before `Close`**. A `Subcontext.Run` executing *concurrently* with `Close` (racy teardown) may be omitted from the aggregate timer/truncations. This is telemetry-only (it never affects WAF decisions) and is documented on `Subcontext.Close` and `Context.Close`. Closing a fully-restructured drain path was intentionally left out of scope to avoid changing the teardown lock model.

## Scope / non-goals

- No dd-trace-go changes (separate repo; this PR only unblocks the cleanup there).
- No `Run` signature changes, no removed/renamed exports (`Handle.Addresses` retained), no `timer`-package API changes.
