### PR TITLE
fix(bindings): compile on 32-bit platforms

### DIFF
--- a/internal/bindings/ctypes.go
+++ b/internal/bindings/ctypes.go
@@ -357,9 +357,7 @@ func (w *WAFObject) SetString(pinner *runtime.Pinner, str string) {
 	// The C size field is uint32; clamp instead of letting the cast wrap
 	// around for pathological (>4GiB) strings. WAFObject is public API, so
 	// callers may reach this without the Encoder's truncation guard.
-	if uint64(length) > math.MaxUint32 {
-		length = math.MaxUint32
-	}
+	length = int(min(uint64(length), math.MaxUint32))
 
 	// Regular string: pin the data pointer
 	w.setType(WAFStringType)
@@ -386,9 +384,7 @@ func (w *WAFObject) SetLiteralString(pinner *runtime.Pinner, str string) {
 	length := header.Len
 
 	// See SetString for why the length is clamped to the uint32 size field.
-	if uint64(length) > math.MaxUint32 {
-		length = math.MaxUint32
-	}
+	length = int(min(uint64(length), math.MaxUint32))
 
 	w.setType(WAFLiteralStringType)
 	binary.NativeEndian.PutUint32(w.data[wafObjectStringSizeOffset:], uint32(length))


### PR DESCRIPTION
### What

`internal/bindings/ctypes.go` fails to compile on 32-bit platforms (`GOARCH=386`, `arm`):

```
internal/bindings/ctypes.go:361:12: cannot use math.MaxUint32 (untyped int constant 4294967295) as int value in assignment (overflows)
internal/bindings/ctypes.go:390:12: cannot use math.MaxUint32 (untyped int constant 4294967295) as int value in assignment (overflows)
```

The two string-length clamps assign the untyped constant `math.MaxUint32` to an `int`. On 32-bit `int` is 32-bit, so the constant does not fit and the build breaks.

`ctypes.go` is ungated and defines the shared `WAFObject` type used by the unsupported-target build path (`waf_dl_unsupported.go`), so it must compile on every architecture — even though the WAF itself only runs on `(amd64|arm64) && (linux|darwin)`. Today it does not, which breaks any downstream module that targets a 32-bit first-class Go port (see DataDog/dd-trace-go#4984).

### How

Route the clamp through a runtime `uint64`→`int` conversion so the constant is never materialized as an `int`:

```go
length = int(min(uint64(length), math.MaxUint32))
```

Behavior is unchanged on 64-bit; on 32-bit the clamp is an unreachable no-op (an `int` cannot exceed 4 GiB, so it can never exceed the uint32 size field).

### Test plan

- `GOOS=linux GOARCH=386 CGO_ENABLED=0 go build ./internal/bindings/` and `GOARCH=arm` — both now succeed (were the reported failure).
- `go test ./internal/bindings/` passes (64-bit behavior unchanged).
- `gofmt` clean. (Two pre-existing `unsafe.Pointer` vet warnings in `waf_dl.go` are unrelated and unchanged.)
